### PR TITLE
Restore the rooms search of Element

### DIFF
--- a/changelog.d/542.misc
+++ b/changelog.d/542.misc
@@ -1,0 +1,1 @@
+Restore the rooms search of Element

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -561,11 +561,10 @@ class HomeActivity :
                 MainActivity.restartApp(this, MainActivityArgs(clearCache = true))
                 return true
             }
-            // Tchap: search is handled in RoomListFragment
-//            R.id.menu_home_filter              -> {
-//                navigator.openRoomsFiltering(this)
-//                return true
-//            }
+            R.id.menu_home_filter              -> {
+                navigator.openRoomsFiltering(this)
+                return true
+            }
             R.id.menu_home_setting             -> {
                 navigator.openSettings(this)
                 return true

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.home
 
 import android.os.Bundle
 import android.view.LayoutInflater
+import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
@@ -111,6 +112,13 @@ class HomeDetailFragment @Inject constructor(
             else                            -> {
                 super.onOptionsItemSelected(item)
             }
+        }
+    }
+
+    override fun onPrepareOptionsMenu(menu: Menu) {
+        withState(viewModel) { state ->
+            val isRoomList = state.currentTab is HomeTab.RoomList
+            menu.findItem(R.id.menu_home_mark_all_as_read).isVisible = isRoomList && hasUnreadRooms
         }
     }
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -117,24 +117,6 @@ class HomeDetailFragment @Inject constructor(
         }
     }
 
-    override fun onPrepareOptionsMenu(menu: Menu) {
-        withState(viewModel) { state ->
-            val isRoomList = state.currentTab is HomeTab.RoomList
-            menu.findItem(R.id.menu_home_mark_all_as_read).isVisible = isRoomList && hasUnreadRooms
-        }
-
-        // Tchap: Update SearchView
-        // - remove max width so it can take the whole available space in landscape
-        // - show same icon as menu item
-        val searchItem = menu.findItem(R.id.menu_home_filter)
-        (searchItem?.actionView as? SearchView)?.run {
-            maxWidth = Int.MAX_VALUE
-            findViewById<ImageView>(androidx.appcompat.R.id.search_mag_icon)?.setImageDrawable(searchItem.icon)
-        }
-
-        super.onPrepareOptionsMenu(menu)
-    }
-
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentHomeDetailBinding {
         return FragmentHomeDetailBinding.inflate(inflater, container, false)
     }

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -18,13 +18,10 @@ package im.vector.app.features.home
 
 import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageView
 import android.widget.Toast
-import androidx.appcompat.widget.SearchView
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -120,6 +120,7 @@ class HomeDetailFragment @Inject constructor(
             val isRoomList = state.currentTab is HomeTab.RoomList
             menu.findItem(R.id.menu_home_mark_all_as_read).isVisible = isRoomList && hasUnreadRooms
         }
+        super.onPrepareOptionsMenu(menu)
     }
 
     override fun getBinding(inflater: LayoutInflater, container: ViewGroup?): FragmentHomeDetailBinding {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListFragment.kt
@@ -19,11 +19,8 @@ package im.vector.app.features.home.room.list
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
-import android.view.Menu
-import android.view.MenuInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
@@ -49,9 +46,7 @@ import im.vector.app.core.platform.VectorBaseFragment
 import im.vector.app.core.resources.UserPreferencesProvider
 import im.vector.app.databinding.FragmentRoomListBinding
 import im.vector.app.features.analytics.plan.MobileScreen
-import im.vector.app.features.home.HomeActivitySharedAction
 import im.vector.app.features.home.HomeSharedActionViewModel
-import im.vector.app.features.home.HomeTab
 import im.vector.app.features.home.RoomListDisplayMode
 import im.vector.app.features.home.room.filtered.FilteredRoomFooterItem
 import im.vector.app.features.home.room.list.actions.RoomListQuickActionsBottomSheet
@@ -61,10 +56,8 @@ import im.vector.app.features.home.room.list.widget.NotifsFabMenuView
 import im.vector.app.features.home.room.list.widget.TchapRoomsFabMenuView
 import im.vector.app.features.notifications.NotificationDrawerManager
 import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -73,7 +66,6 @@ import org.matrix.android.sdk.api.session.room.model.RoomSummary
 import org.matrix.android.sdk.api.session.room.model.SpaceChildInfo
 import org.matrix.android.sdk.api.session.room.model.tag.RoomTag
 import org.matrix.android.sdk.api.session.room.notification.RoomNotificationState
-import reactivecircus.flowbinding.appcompat.queryTextChanges
 import javax.inject.Inject
 
 @Parcelize

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListSectionBuilderGroup.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListSectionBuilderGroup.kt
@@ -255,8 +255,6 @@ class RoomListSectionBuilderGroup(
             val name = stringProvider.getString(nameRes)
             session.getFilteredPagedRoomSummariesLive(roomQueryParams)
                     .also {
-                        // Tchap: Refresh RoomList
-                        onUpdatable(it)
                         activeSpaceUpdaters.add(it)
                     }.livePagedList
                     .let { livePagedList ->

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListSectionBuilderSpace.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListSectionBuilderSpace.kt
@@ -357,8 +357,7 @@ class RoomListSectionBuilderSpace(
             val filteredPagedRoomSummariesLive = session.getFilteredPagedRoomSummariesLive(
                     roomQueryParams.process(spaceFilterStrategy, appStateHandler.safeActiveSpaceId()),
                     pagedListConfig
-            // Tchap: Refresh room list
-            ).also(onUpdatable)
+            )
             when (spaceFilterStrategy) {
                 RoomListViewModel.SpaceFilterStrategy.ORPHANS_IF_SPACE_NULL -> {
                     activeSpaceUpdaters.add(object : RoomListViewModel.ActiveSpaceQueryUpdater {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
@@ -22,7 +22,6 @@ import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Success
-import com.airbnb.mvrx.ViewModelContext
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -31,7 +30,6 @@ import im.vector.app.RoomGroupingMethod
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.extensions.exhaustive
-import im.vector.app.core.extensions.singletonEntryPoint
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.features.analytics.AnalyticsTracker

--- a/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/RoomListViewModel.kt
@@ -122,15 +122,7 @@ class RoomListViewModel @AssistedInject constructor(
                 }
     }
 
-    companion object : MavericksViewModelFactory<RoomListViewModel, RoomListViewState> by hiltMavericksViewModelFactory() {
-
-        override fun initialState(viewModelContext: ViewModelContext): RoomListViewState {
-            val uiStateRepository = viewModelContext.activity.singletonEntryPoint().uiStateRepository()
-            return RoomListViewState(
-                    displayMode = uiStateRepository.getDisplayMode()
-            )
-        }
-    }
+    companion object : MavericksViewModelFactory<RoomListViewModel, RoomListViewState> by hiltMavericksViewModelFactory()
 
     private val roomListSectionBuilder = if (appStateHandler.getCurrentRoomGroupingMethod() is RoomGroupingMethod.BySpace) {
         RoomListSectionBuilderSpace(

--- a/vector/src/main/res/menu/home.xml
+++ b/vector/src/main/res/menu/home.xml
@@ -29,13 +29,10 @@
         android:title="Do an optimized init sync"
         tools:ignore="HardcodedText" />
 
-    <!-- Tchap: Use searchView widget -->
     <item
         android:id="@+id/menu_home_filter"
         android:icon="@drawable/ic_filter"
         android:title="@string/home_filter_placeholder_home"
-        app:actionViewClass="androidx.appcompat.widget.SearchView"
         app:iconTint="?vctr_content_secondary"
-        app:showAsAction="collapseActionView|always" />
-
+        app:showAsAction="always" />
 </menu>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [X] Other :

## Content
#542 

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs
![Screenshot_1650534834](https://user-images.githubusercontent.com/15031750/164430790-256ee2c2-77ab-49a3-9fa4-50f7729eb3f7.png)

<!-- Only if UI have been changed -->

## Tests

## Tested devices

- [ ] Physical
- [X] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [] Changes has been tested on an Android device or Android emulator with API 21
- [X] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#accessibility
- [X] Pull request is based on the develop branch
- [X] Pull request updates [TCHAP_CHANGES.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/TCHAP_CHANGES.md)
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android-v2/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
