### PR TITLE
Move BuildConfig fields to vector-configs module

### DIFF
--- a/vector-config/build.gradle
+++ b/vector-config/build.gradle
@@ -10,6 +10,15 @@ android {
         minSdk versions.minSdk
         targetSdk versions.targetSdk
     }
+
+    // The 'voip' flavor dimension permits to include/exclude jitsi at compilation time
+    flavorDimensions "voip"
+
+    productFlavors {
+        withvoip { dimension "voip" }
+        withoutvoip { dimension "voip" }
+    }
+
     compileOptions {
         sourceCompatibility versions.sourceCompat
         targetCompatibility versions.targetCompat

--- a/vector-config/build.gradle
+++ b/vector-config/build.gradle
@@ -11,12 +11,17 @@ android {
         targetSdk versions.targetSdk
     }
 
+    // The 'target' dimension permits to specify which platform are used
     // The 'voip' flavor dimension permits to include/exclude jitsi at compilation time
-    flavorDimensions "voip"
+    flavorDimensions "target", "voip"
 
     productFlavors {
         withvoip { dimension "voip" }
         withoutvoip { dimension "voip" }
+
+        devTchap { dimension "target" }
+        btchap { dimension "target" }
+        tchap { dimension "target" }
     }
 
     compileOptions {

--- a/vector-config/src/btchap/res/values/config-features.xml
+++ b/vector-config/src/btchap/res/values/config-features.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="tchap_is_cross_signing_enabled">true</bool>
+    <bool name="tchap_is_key_backup_enabled">false</bool>
+</resources>

--- a/vector-config/src/btchap/res/values/config-settings.xml
+++ b/vector-config/src/btchap/res/values/config-settings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="tchap_settings_root_labs_visible">true</bool>
+</resources>

--- a/vector-config/src/debug/res/values/config-settings.xml
+++ b/vector-config/src/debug/res/values/config-settings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Level 1: Advanced settings -->
+    <bool name="tchap_settings_advanced_developer_mode_visible">true</bool> <!-- Tchap: Show developer mode in debug -->
+
+</resources>

--- a/vector-config/src/devTchap/res/values/config-features.xml
+++ b/vector-config/src/devTchap/res/values/config-features.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="tchap_is_cross_signing_enabled">true</bool>
+    <bool name="tchap_is_key_backup_enabled">true</bool>
+</resources>

--- a/vector-config/src/devTchap/res/values/config-settings.xml
+++ b/vector-config/src/devTchap/res/values/config-settings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="tchap_settings_root_labs_visible">true</bool>
+</resources>

--- a/vector-config/src/main/res/values/config-settings.xml
+++ b/vector-config/src/main/res/values/config-settings.xml
@@ -29,9 +29,11 @@
 
     <!-- Level 1: Preferences -->
 
+    <bool name="tchap_settings_spaces_visible">false</bool> <!-- Tchap: Hide spaces -->
+    <bool name="tchap_settings_spaces_show_all_room_in_home_default">true</bool> <!-- Tchap: Show all room in home while spaces are hidden -->
+
     <bool name="settings_interface_bubble_visible">true</bool>
-    <!-- Tchap: Enable message bubbles by default -->
-    <bool name="settings_interface_bubble_default">true</bool>
+    <bool name="settings_interface_bubble_default">true</bool> <!-- Tchap: Enable message bubbles by default -->
     <bool name="settings_presence_visible">false</bool>
     <bool name="settings_presence_user_always_appears_offline_default">false</bool>
 
@@ -42,10 +44,14 @@
     <bool name="settings_ignored_users_visible">true</bool>
 
     <!-- Level 1: Labs -->
+    <bool name="tchap_settings_labs_enable_location_sharing">false</bool> <!-- Tchap: Disable Location Sharing -->
+
     <bool name="settings_labs_thread_messages_default">false</bool>
     <bool name="settings_timeline_show_live_sender_info_visible">true</bool>
     <bool name="settings_timeline_show_live_sender_info_default">false</bool>
+
     <!-- Level 1: Advanced settings -->
+    <bool name="tchap_settings_advanced_developer_mode_visible">false</bool> <!-- Tchap: Hide developer mode in release -->
 
     <!-- Level 1: Help and about -->
 

--- a/vector-config/src/tchap/res/values/config-features.xml
+++ b/vector-config/src/tchap/res/values/config-features.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="tchap_is_cross_signing_enabled">false</bool>
+    <bool name="tchap_is_key_backup_enabled">false</bool>
+</resources>

--- a/vector-config/src/tchap/res/values/config-settings.xml
+++ b/vector-config/src/tchap/res/values/config-settings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="tchap_settings_root_labs_visible">false</bool>
+</resources>

--- a/vector-config/src/withoutvoip/res/values/config-features.xml
+++ b/vector-config/src/withoutvoip/res/values/config-features.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="tchap_is_voip_supported">false</bool>
+</resources>

--- a/vector-config/src/withvoip/res/values/config-features.xml
+++ b/vector-config/src/withvoip/res/values/config-features.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="tchap_is_voip_supported">true</bool>
+</resources>

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -335,16 +335,10 @@ android {
 
         withvoip {
             dimension "voip"
-
-            buildConfigField "boolean", "IS_VOIP_SUPPORTED", "true"
-            resValue "bool", "is_voip_supported", "true"
         }
 
         withoutvoip {
             dimension "voip"
-
-            buildConfigField "boolean", "IS_VOIP_SUPPORTED", "false"
-            resValue "bool", "is_voip_supported", "false"
         }
 
         withpinning {

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -347,9 +347,6 @@ android {
             applicationId "fr.gouv.tchap.dev"
             versionName "${versionMajor}.${versionMinor}.${versionPatch}${getGplayVersionSuffix()}" + "_dev"
 
-            // Tchap: Show labs menu item in devTchap
-            resValue "bool", "labs_settings_visible", "true"
-
             // Tchap: CrossSigning initialization is disabled
             def enableCrossSigning = true
             buildConfigField "Boolean", "ENABLE_CROSS_SIGNING", "${enableCrossSigning}"
@@ -367,9 +364,6 @@ android {
             applicationId "fr.gouv.rie.tchap"
             versionName "${versionMajor}.${versionMinor}.${versionPatch}${getGplayVersionSuffix()}" + "_b"
 
-            // Tchap: Show labs menu item in btchap
-            resValue "bool", "labs_settings_visible", "true"
-
             // Tchap: CrossSigning initialization is disabled
             def enableCrossSigning = true
             buildConfigField "Boolean", "ENABLE_CROSS_SIGNING", "${enableCrossSigning}"
@@ -386,9 +380,6 @@ android {
 
             applicationId "fr.gouv.tchap.a"
             versionName "${versionMajor}.${versionMinor}.${versionPatch}${getGplayVersionSuffix()}"
-
-            // Tchap: Hide labs menu item in tchap
-            resValue "bool", "labs_settings_visible", "false"
 
             // Tchap: CrossSigning initialization is disabled
             def enableCrossSigning = false

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -346,14 +346,6 @@ android {
 
             applicationId "fr.gouv.tchap.dev"
             versionName "${versionMajor}.${versionMinor}.${versionPatch}${getGplayVersionSuffix()}" + "_dev"
-
-            // Tchap: CrossSigning initialization is disabled
-            def enableCrossSigning = true
-            buildConfigField "Boolean", "ENABLE_CROSS_SIGNING", "${enableCrossSigning}"
-            resValue "bool", "enable_cross_signing", "${enableCrossSigning}"
-
-            // Tchap: Key Backup is not supported
-            buildConfigField "Boolean", "IS_KEY_BACKUP_SUPPORTED", "true"
         }
 
         btchap {
@@ -363,14 +355,6 @@ android {
 
             applicationId "fr.gouv.rie.tchap"
             versionName "${versionMajor}.${versionMinor}.${versionPatch}${getGplayVersionSuffix()}" + "_b"
-
-            // Tchap: CrossSigning initialization is disabled
-            def enableCrossSigning = true
-            buildConfigField "Boolean", "ENABLE_CROSS_SIGNING", "${enableCrossSigning}"
-            resValue "bool", "enable_cross_signing", "${enableCrossSigning}"
-
-            // Tchap: Key Backup is not supported
-            buildConfigField "Boolean", "IS_KEY_BACKUP_SUPPORTED", "false"
         }
 
         tchap {
@@ -380,14 +364,6 @@ android {
 
             applicationId "fr.gouv.tchap.a"
             versionName "${versionMajor}.${versionMinor}.${versionPatch}${getGplayVersionSuffix()}"
-
-            // Tchap: CrossSigning initialization is disabled
-            def enableCrossSigning = false
-            buildConfigField "Boolean", "ENABLE_CROSS_SIGNING", "${enableCrossSigning}"
-            resValue "bool", "enable_cross_signing", "${enableCrossSigning}"
-
-            // Tchap: Key Backup is not supported
-            buildConfigField "Boolean", "IS_KEY_BACKUP_SUPPORTED", "false"
         }
     }
 

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -333,21 +333,11 @@ android {
             buildConfigField "String", "FLAVOR_DESCRIPTION", "\"FDroid\""
         }
 
-        withvoip {
-            dimension "voip"
-        }
+        withvoip { dimension "voip" }
+        withoutvoip { dimension "voip" }
 
-        withoutvoip {
-            dimension "voip"
-        }
-
-        withpinning {
-            dimension "pinning"
-        }
-
-        withoutpinning {
-            dimension "pinning"
-        }
+        withpinning { dimension "pinning" }
+        withoutpinning { dimension "pinning" }
 
         devTchap {
             dimension "target"

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -158,15 +158,6 @@ android {
         buildConfigField "String", "GIT_BRANCH_NAME", "\"${gitBranchName()}\""
         buildConfigField "String", "BUILD_NUMBER", "\"${buildNumber}\""
 
-        // Tchap: Disable Location Sharing
-        resValue "bool", "enable_location_sharing", "false"
-
-        // Tchap: The spaces feature is hidden, show all rooms in the home
-        def showSpaces = false
-        def showAllInHome = !showSpaces
-        resValue "bool", "show_spaces", "${showSpaces}"
-        resValue "bool", "spaces_show_all_in_home", "${showAllInHome}"
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         // Tchap: Disable universalApk
@@ -255,9 +246,6 @@ android {
 //            resValue "string", "app_name", "Element dbg"
 //            resValue "color", "launcher_background", "#0DBD8B"
 
-            // Tchap: Show developer mode only in debug
-            resValue "bool", "developer_mode_visible", "true"
-
             signingConfig signingConfigs.debug
 
             if (project.hasProperty("coverage")) {
@@ -268,9 +256,6 @@ android {
         release {
 //            resValue "string", "app_name", "Element"
 //            resValue "color", "launcher_background", "#0DBD8B"
-
-            // Tchap: Show developer mode only in debug
-            resValue "bool", "developer_mode_visible", "false"
 
             postprocessing {
                 removeUnusedCode true

--- a/vector/src/androidTest/java/im/vector/app/CantVerifyTest.kt
+++ b/vector/src/androidTest/java/im/vector/app/CantVerifyTest.kt
@@ -25,7 +25,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import im.vector.app.features.MainActivity
 import im.vector.app.ui.robot.ElementRobot
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -34,7 +33,6 @@ import java.util.UUID
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
-@Ignore("Tchap: Secure Backup is disabled, so this test cannot succeed")
 class CantVerifyTest : VerificationTestBase() {
 
     @get:Rule

--- a/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderProviderTests.kt
+++ b/vector/src/androidTest/java/im/vector/app/features/voice/VoiceRecorderProviderTests.kt
@@ -19,6 +19,7 @@ package im.vector.app.features.voice
 import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
 import im.vector.app.AndroidVersionTestOverrider
+import im.vector.app.core.resources.BooleanProvider
 import im.vector.app.features.DefaultVectorFeatures
 import org.amshove.kluent.shouldBeInstanceOf
 import org.junit.After
@@ -27,7 +28,8 @@ import org.junit.Test
 class VoiceRecorderProviderTests {
 
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val provider = VoiceRecorderProvider(context, DefaultVectorFeatures())
+    private val booleanProvider = BooleanProvider(context.resources)
+    private val provider = VoiceRecorderProvider(context, DefaultVectorFeatures(booleanProvider))
 
     @After
     fun tearDown() {

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/OnboardingRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/OnboardingRobot.kt
@@ -30,6 +30,7 @@ import com.adevinta.android.barista.interaction.BaristaClickInteractions.clickOn
 import com.adevinta.android.barista.interaction.BaristaEditTextInteractions.writeTo
 import im.vector.app.R
 import im.vector.app.config.OnboardingVariant
+import im.vector.app.core.resources.BooleanProvider
 import im.vector.app.espresso.tools.waitUntilViewVisible
 import im.vector.app.features.DefaultVectorFeatures
 import im.vector.app.features.debug.features.DebugVectorFeatures
@@ -39,7 +40,8 @@ class OnboardingRobot {
 
     // Tchap: Use different onboarding variant to run the tests
     private val context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val defaultVectorFeatures = DebugVectorFeatures(context, DefaultVectorFeatures()).apply {
+    private val booleanProvider = BooleanProvider(context.resources)
+    private val defaultVectorFeatures = DebugVectorFeatures(context, DefaultVectorFeatures(booleanProvider)).apply {
         overrideEnum(OnboardingVariant.FTUE_AUTH, OnboardingVariant::class)
     }
 

--- a/vector/src/androidTest/java/im/vector/app/ui/robot/OnboardingRobot.kt
+++ b/vector/src/androidTest/java/im/vector/app/ui/robot/OnboardingRobot.kt
@@ -33,6 +33,7 @@ import im.vector.app.config.OnboardingVariant
 import im.vector.app.core.resources.BooleanProvider
 import im.vector.app.espresso.tools.waitUntilViewVisible
 import im.vector.app.features.DefaultVectorFeatures
+import im.vector.app.features.debug.features.DebugFeatureKeys
 import im.vector.app.features.debug.features.DebugVectorFeatures
 import im.vector.app.waitForView
 
@@ -43,6 +44,7 @@ class OnboardingRobot {
     private val booleanProvider = BooleanProvider(context.resources)
     private val defaultVectorFeatures = DebugVectorFeatures(context, DefaultVectorFeatures(booleanProvider)).apply {
         overrideEnum(OnboardingVariant.FTUE_AUTH, OnboardingVariant::class)
+        override(true, DebugFeatureKeys.tchapIsKeyBackupEnabled)
     }
 
     fun crawl() {

--- a/vector/src/debug/java/im/vector/app/features/debug/di/FeaturesModule.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/di/FeaturesModule.kt
@@ -22,6 +22,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import im.vector.app.core.resources.BooleanProvider
 import im.vector.app.features.DefaultVectorFeatures
 import im.vector.app.features.DefaultVectorOverrides
 import im.vector.app.features.VectorFeatures
@@ -42,8 +43,8 @@ interface FeaturesModule {
     companion object {
 
         @Provides
-        fun providesDefaultVectorFeatures(): DefaultVectorFeatures {
-            return DefaultVectorFeatures()
+        fun providesDefaultVectorFeatures(booleanProvider: BooleanProvider): DefaultVectorFeatures {
+            return DefaultVectorFeatures(booleanProvider)
         }
 
         @Provides

--- a/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
@@ -40,6 +40,12 @@ class DebugVectorFeatures(
 
     private val dataStore = context.dataStore
 
+    override fun isVoipSupported() = vectorFeatures.isVoipSupported()
+
+    override fun isCrossSigningEnabled() = vectorFeatures.isCrossSigningEnabled()
+
+    override fun isKeyBackupEnabled() = vectorFeatures.isKeyBackupEnabled()
+
     override fun onboardingVariant(): OnboardingVariant {
         return readPreferences().getEnum<OnboardingVariant>() ?: vectorFeatures.onboardingVariant()
     }

--- a/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
@@ -44,7 +44,7 @@ class DebugVectorFeatures(
 
     override fun isCrossSigningEnabled() = vectorFeatures.isCrossSigningEnabled()
 
-    override fun isKeyBackupEnabled() = vectorFeatures.isKeyBackupEnabled()
+    override fun isKeyBackupEnabled() = read(DebugFeatureKeys.tchapIsKeyBackupEnabled) ?: vectorFeatures.isKeyBackupEnabled()
 
     override fun onboardingVariant(): OnboardingVariant {
         return readPreferences().getEnum<OnboardingVariant>() ?: vectorFeatures.onboardingVariant()
@@ -133,6 +133,7 @@ private inline fun <reified T : Enum<T>> enumPreferencesKey() = enumPreferencesK
 private fun <T : Enum<T>> enumPreferencesKey(type: KClass<T>) = stringPreferencesKey("enum-${type.simpleName}")
 
 object DebugFeatureKeys {
+    val tchapIsKeyBackupEnabled = booleanPreferencesKey("tchap_is_key_backup_enabled")
     val onboardingAlreadyHaveAnAccount = booleanPreferencesKey("onboarding-already-have-an-account")
     val onboardingSplashCarousel = booleanPreferencesKey("onboarding-splash-carousel")
     val onboardingUseCase = booleanPreferencesKey("onboarding-use-case")

--- a/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
@@ -44,7 +44,7 @@ class DebugVectorFeatures(
 
     override fun tchapIsCrossSigningEnabled() = vectorFeatures.tchapIsCrossSigningEnabled()
 
-    override fun isKeyBackupEnabled() = read(DebugFeatureKeys.tchapIsKeyBackupEnabled) ?: vectorFeatures.isKeyBackupEnabled()
+    override fun tchapIsKeyBackupEnabled() = read(DebugFeatureKeys.tchapIsKeyBackupEnabled) ?: vectorFeatures.tchapIsKeyBackupEnabled()
 
     override fun onboardingVariant(): OnboardingVariant {
         return readPreferences().getEnum<OnboardingVariant>() ?: vectorFeatures.onboardingVariant()

--- a/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
@@ -40,7 +40,7 @@ class DebugVectorFeatures(
 
     private val dataStore = context.dataStore
 
-    override fun isVoipSupported() = vectorFeatures.isVoipSupported()
+    override fun tchapIsVoipSupported() = vectorFeatures.tchapIsVoipSupported()
 
     override fun isCrossSigningEnabled() = vectorFeatures.isCrossSigningEnabled()
 

--- a/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
+++ b/vector/src/debug/java/im/vector/app/features/debug/features/DebugVectorFeatures.kt
@@ -42,7 +42,7 @@ class DebugVectorFeatures(
 
     override fun tchapIsVoipSupported() = vectorFeatures.tchapIsVoipSupported()
 
-    override fun isCrossSigningEnabled() = vectorFeatures.isCrossSigningEnabled()
+    override fun tchapIsCrossSigningEnabled() = vectorFeatures.tchapIsCrossSigningEnabled()
 
     override fun isKeyBackupEnabled() = read(DebugFeatureKeys.tchapIsKeyBackupEnabled) ?: vectorFeatures.isKeyBackupEnabled()
 

--- a/vector/src/main/java/im/vector/app/VectorApplication.kt
+++ b/vector/src/main/java/im/vector/app/VectorApplication.kt
@@ -47,6 +47,7 @@ import dagger.hilt.android.HiltAndroidApp
 import im.vector.app.config.Config
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.resources.BuildMeta
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.VectorAnalytics
 import im.vector.app.features.call.webrtc.WebRtcCallManager
 import im.vector.app.features.configuration.VectorConfiguration
@@ -82,6 +83,7 @@ class VectorApplication :
         WorkConfiguration.Provider {
 
     lateinit var appContext: Context
+    @Inject lateinit var vectorFeatures: VectorFeatures
     @Inject lateinit var legacySessionImporter: LegacySessionImporter
     @Inject lateinit var authenticationService: AuthenticationService
     @Inject lateinit var vectorConfiguration: VectorConfiguration
@@ -129,7 +131,7 @@ class VectorApplication :
         vectorUncaughtExceptionHandler.activate()
 
         // Remove Log handler statically added by Jitsi
-        if (BuildConfig.IS_VOIP_SUPPORTED) {
+        if (vectorFeatures.isVoipSupported()) {
             Timber.forest()
                     .filter { it::class.java.name == "org.jitsi.meet.sdk.log.JitsiMeetDefaultLogHandler" }
                     .forEach { Timber.uproot(it) }

--- a/vector/src/main/java/im/vector/app/VectorApplication.kt
+++ b/vector/src/main/java/im/vector/app/VectorApplication.kt
@@ -131,7 +131,7 @@ class VectorApplication :
         vectorUncaughtExceptionHandler.activate()
 
         // Remove Log handler statically added by Jitsi
-        if (vectorFeatures.isVoipSupported()) {
+        if (vectorFeatures.tchapIsVoipSupported()) {
             Timber.forest()
                     .filter { it::class.java.name == "org.jitsi.meet.sdk.log.JitsiMeetDefaultLogHandler" }
                     .forEach { Timber.uproot(it) }

--- a/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
+++ b/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
@@ -25,7 +25,7 @@ import javax.inject.Inject
 interface VectorFeatures {
 
     fun tchapIsVoipSupported(): Boolean
-    fun isCrossSigningEnabled(): Boolean
+    fun tchapIsCrossSigningEnabled(): Boolean
     fun isKeyBackupEnabled(): Boolean
     fun onboardingVariant(): OnboardingVariant
     fun isOnboardingAlreadyHaveAccountSplashEnabled(): Boolean
@@ -46,7 +46,7 @@ class DefaultVectorFeatures @Inject constructor(
         private val booleanProvider: BooleanProvider
 ) : VectorFeatures {
     override fun tchapIsVoipSupported() = booleanProvider.getBoolean(R.bool.tchap_is_voip_supported)
-    override fun isCrossSigningEnabled() = booleanProvider.getBoolean(R.bool.tchap_is_cross_signing_enabled)
+    override fun tchapIsCrossSigningEnabled() = booleanProvider.getBoolean(R.bool.tchap_is_cross_signing_enabled)
     override fun isKeyBackupEnabled() = booleanProvider.getBoolean(R.bool.tchap_is_key_backup_enabled)
     override fun onboardingVariant() = Config.ONBOARDING_VARIANT
     override fun isOnboardingAlreadyHaveAccountSplashEnabled() = true

--- a/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
+++ b/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
@@ -24,6 +24,8 @@ import im.vector.app.core.resources.BooleanProvider
 interface VectorFeatures {
 
     fun isVoipSupported(): Boolean
+    fun isCrossSigningEnabled(): Boolean
+    fun isKeyBackupEnabled(): Boolean
     fun onboardingVariant(): OnboardingVariant
     fun isOnboardingAlreadyHaveAccountSplashEnabled(): Boolean
     fun isOnboardingSplashCarouselEnabled(): Boolean
@@ -42,6 +44,9 @@ interface VectorFeatures {
 class DefaultVectorFeatures(
         private val booleanProvider: BooleanProvider
 ) : VectorFeatures {
+    override fun isVoipSupported() = booleanProvider.getBoolean(R.bool.tchap_is_voip_supported)
+    override fun isCrossSigningEnabled() = booleanProvider.getBoolean(R.bool.tchap_is_cross_signing_enabled)
+    override fun isKeyBackupEnabled() = booleanProvider.getBoolean(R.bool.tchap_is_key_backup_enabled)
     override fun onboardingVariant() = Config.ONBOARDING_VARIANT
     override fun isOnboardingAlreadyHaveAccountSplashEnabled() = true
     override fun isOnboardingSplashCarouselEnabled() = true
@@ -55,5 +60,4 @@ class DefaultVectorFeatures(
     override fun forceUsageOfOpusEncoder(): Boolean = false
     override fun shouldStartDmOnFirstMessage(): Boolean = false
     override fun isNewAppLayoutEnabled(): Boolean = false
-    override fun isVoipSupported(): Boolean = booleanProvider.getBoolean(R.bool.tchap_is_voip_supported)
 }

--- a/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
+++ b/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
@@ -24,7 +24,7 @@ import javax.inject.Inject
 
 interface VectorFeatures {
 
-    fun isVoipSupported(): Boolean
+    fun tchapIsVoipSupported(): Boolean
     fun isCrossSigningEnabled(): Boolean
     fun isKeyBackupEnabled(): Boolean
     fun onboardingVariant(): OnboardingVariant
@@ -45,7 +45,7 @@ interface VectorFeatures {
 class DefaultVectorFeatures @Inject constructor(
         private val booleanProvider: BooleanProvider
 ) : VectorFeatures {
-    override fun isVoipSupported() = booleanProvider.getBoolean(R.bool.tchap_is_voip_supported)
+    override fun tchapIsVoipSupported() = booleanProvider.getBoolean(R.bool.tchap_is_voip_supported)
     override fun isCrossSigningEnabled() = booleanProvider.getBoolean(R.bool.tchap_is_cross_signing_enabled)
     override fun isKeyBackupEnabled() = booleanProvider.getBoolean(R.bool.tchap_is_key_backup_enabled)
     override fun onboardingVariant() = Config.ONBOARDING_VARIANT

--- a/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
+++ b/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
@@ -16,11 +16,14 @@
 
 package im.vector.app.features
 
+import im.vector.app.R
 import im.vector.app.config.Config
 import im.vector.app.config.OnboardingVariant
+import im.vector.app.core.resources.BooleanProvider
 
 interface VectorFeatures {
 
+    fun isVoipSupported(): Boolean
     fun onboardingVariant(): OnboardingVariant
     fun isOnboardingAlreadyHaveAccountSplashEnabled(): Boolean
     fun isOnboardingSplashCarouselEnabled(): Boolean
@@ -36,7 +39,9 @@ interface VectorFeatures {
     fun isNewAppLayoutEnabled(): Boolean
 }
 
-class DefaultVectorFeatures : VectorFeatures {
+class DefaultVectorFeatures(
+        private val booleanProvider: BooleanProvider
+) : VectorFeatures {
     override fun onboardingVariant() = Config.ONBOARDING_VARIANT
     override fun isOnboardingAlreadyHaveAccountSplashEnabled() = true
     override fun isOnboardingSplashCarouselEnabled() = true
@@ -50,4 +55,5 @@ class DefaultVectorFeatures : VectorFeatures {
     override fun forceUsageOfOpusEncoder(): Boolean = false
     override fun shouldStartDmOnFirstMessage(): Boolean = false
     override fun isNewAppLayoutEnabled(): Boolean = false
+    override fun isVoipSupported(): Boolean = booleanProvider.getBoolean(R.bool.tchap_is_voip_supported)
 }

--- a/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
+++ b/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
@@ -26,7 +26,7 @@ interface VectorFeatures {
 
     fun tchapIsVoipSupported(): Boolean
     fun tchapIsCrossSigningEnabled(): Boolean
-    fun isKeyBackupEnabled(): Boolean
+    fun tchapIsKeyBackupEnabled(): Boolean
     fun onboardingVariant(): OnboardingVariant
     fun isOnboardingAlreadyHaveAccountSplashEnabled(): Boolean
     fun isOnboardingSplashCarouselEnabled(): Boolean
@@ -47,7 +47,7 @@ class DefaultVectorFeatures @Inject constructor(
 ) : VectorFeatures {
     override fun tchapIsVoipSupported() = booleanProvider.getBoolean(R.bool.tchap_is_voip_supported)
     override fun tchapIsCrossSigningEnabled() = booleanProvider.getBoolean(R.bool.tchap_is_cross_signing_enabled)
-    override fun isKeyBackupEnabled() = booleanProvider.getBoolean(R.bool.tchap_is_key_backup_enabled)
+    override fun tchapIsKeyBackupEnabled() = booleanProvider.getBoolean(R.bool.tchap_is_key_backup_enabled)
     override fun onboardingVariant() = Config.ONBOARDING_VARIANT
     override fun isOnboardingAlreadyHaveAccountSplashEnabled() = true
     override fun isOnboardingSplashCarouselEnabled() = true

--- a/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
+++ b/vector/src/main/java/im/vector/app/features/VectorFeatures.kt
@@ -20,6 +20,7 @@ import im.vector.app.R
 import im.vector.app.config.Config
 import im.vector.app.config.OnboardingVariant
 import im.vector.app.core.resources.BooleanProvider
+import javax.inject.Inject
 
 interface VectorFeatures {
 
@@ -41,7 +42,7 @@ interface VectorFeatures {
     fun isNewAppLayoutEnabled(): Boolean
 }
 
-class DefaultVectorFeatures(
+class DefaultVectorFeatures @Inject constructor(
         private val booleanProvider: BooleanProvider
 ) : VectorFeatures {
     override fun isVoipSupported() = booleanProvider.getBoolean(R.bool.tchap_is_voip_supported)

--- a/vector/src/main/java/im/vector/app/features/crypto/keysrequest/KeyRequestHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysrequest/KeyRequestHandler.kt
@@ -17,10 +17,10 @@
 package im.vector.app.features.crypto.keysrequest
 
 import android.content.Context
-import im.vector.app.BuildConfig
 import im.vector.app.R
 import im.vector.app.core.date.DateFormatKind
 import im.vector.app.core.date.VectorDateFormatter
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.popup.DefaultVectorAlert
 import im.vector.app.features.popup.PopupAlertManager
 import im.vector.app.features.session.coroutineScope
@@ -52,6 +52,7 @@ import javax.inject.Singleton
 
 @Singleton
 class KeyRequestHandler @Inject constructor(
+        private val vectorFeatures: VectorFeatures,
         private val context: Context,
         private val popupAlertManager: PopupAlertManager,
         private val dateFormatter: VectorDateFormatter
@@ -121,7 +122,7 @@ class KeyRequestHandler @Inject constructor(
                     return
                 }
 
-                if (BuildConfig.ENABLE_CROSS_SIGNING) {
+                if (vectorFeatures.isCrossSigningEnabled()) {
                     if (deviceInfo.isUnknown) {
                         session?.cryptoService()?.setDeviceVerification(
                                 DeviceTrustLevel(crossSigningVerified = false, locallyVerified = false), userId, deviceId)

--- a/vector/src/main/java/im/vector/app/features/crypto/keysrequest/KeyRequestHandler.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/keysrequest/KeyRequestHandler.kt
@@ -122,7 +122,7 @@ class KeyRequestHandler @Inject constructor(
                     return
                 }
 
-                if (vectorFeatures.isCrossSigningEnabled()) {
+                if (vectorFeatures.tchapIsCrossSigningEnabled()) {
                     if (deviceInfo.isUnknown) {
                         session?.cryptoService()?.setDeviceVerification(
                                 DeviceTrustLevel(crossSigningVerified = false, locallyVerified = false), userId, deviceId)

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/request/VerificationRequestController.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/request/VerificationRequestController.kt
@@ -73,7 +73,7 @@ class VerificationRequestController @Inject constructor(
                 }
             }
 
-            if (vectorFeatures.isKeyBackupEnabled() && state.quadSContainsSecrets) {
+            if (vectorFeatures.tchapIsKeyBackupEnabled() && state.quadSContainsSecrets) {
                 val subtitle = if (state.hasAnyOtherSession) {
                     stringProvider.getString(R.string.verification_use_passphrase)
                 } else {

--- a/vector/src/main/java/im/vector/app/features/crypto/verification/request/VerificationRequestController.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/verification/request/VerificationRequestController.kt
@@ -22,12 +22,12 @@ import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
-import im.vector.app.BuildConfig
 import im.vector.app.R
 import im.vector.app.core.epoxy.bottomSheetDividerItem
 import im.vector.app.core.resources.ColorProvider
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.utils.colorizeMatchingText
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.crypto.verification.VerificationBottomSheetViewState
 import im.vector.app.features.crypto.verification.epoxy.bottomSheetSelfWaitItem
 import im.vector.app.features.crypto.verification.epoxy.bottomSheetVerificationActionItem
@@ -38,6 +38,7 @@ import im.vector.lib.core.utils.epoxy.charsequence.toEpoxyCharSequence
 import javax.inject.Inject
 
 class VerificationRequestController @Inject constructor(
+        private val vectorFeatures: VectorFeatures,
         private val stringProvider: StringProvider,
         private val colorProvider: ColorProvider
 ) : EpoxyController() {
@@ -72,7 +73,7 @@ class VerificationRequestController @Inject constructor(
                 }
             }
 
-            if (BuildConfig.IS_KEY_BACKUP_SUPPORTED && state.quadSContainsSecrets) {
+            if (vectorFeatures.isKeyBackupEnabled() && state.quadSContainsSecrets) {
                 val subtitle = if (state.hasAnyOtherSession) {
                     stringProvider.getString(R.string.verification_use_passphrase)
                 } else {

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -22,11 +22,11 @@ import com.airbnb.mvrx.ViewModelContext
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import im.vector.app.BuildConfig
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.VectorViewModel
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.AnalyticsConfig
 import im.vector.app.features.analytics.AnalyticsTracker
 import im.vector.app.features.analytics.extensions.toAnalyticsType
@@ -74,6 +74,7 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 class HomeActivityViewModel @AssistedInject constructor(
+        private val vectorFeatures: VectorFeatures,
         @Assisted private val initialState: HomeActivityViewState,
         private val activeSessionHolder: ActiveSessionHolder,
         private val rawService: RawService,
@@ -103,7 +104,7 @@ class HomeActivityViewModel @AssistedInject constructor(
     private var checkBootstrap = false
 
     // Tchap: Disable cross-signing
-    private var hasCheckedBootstrap = !BuildConfig.ENABLE_CROSS_SIGNING
+    private var hasCheckedBootstrap = !vectorFeatures.isCrossSigningEnabled()
     private var onceTrusted = false
 
     private fun initialize() {
@@ -170,8 +171,7 @@ class HomeActivityViewModel @AssistedInject constructor(
                 .onEach { info ->
                     // Tchap: Disable cross-signing
                     val mxCrossSigningInfo = info.getOrNull()
-
-                    if (!BuildConfig.ENABLE_CROSS_SIGNING && mxCrossSigningInfo != null) {
+                    if (!vectorFeatures.isCrossSigningEnabled() && mxCrossSigningInfo != null) {
                         Timber.i("Cross signing feature is disabled. This account should not have cross signing keys")
                     }
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivityViewModel.kt
@@ -104,7 +104,7 @@ class HomeActivityViewModel @AssistedInject constructor(
     private var checkBootstrap = false
 
     // Tchap: Disable cross-signing
-    private var hasCheckedBootstrap = !vectorFeatures.isCrossSigningEnabled()
+    private var hasCheckedBootstrap = !vectorFeatures.tchapIsCrossSigningEnabled()
     private var onceTrusted = false
 
     private fun initialize() {
@@ -171,7 +171,7 @@ class HomeActivityViewModel @AssistedInject constructor(
                 .onEach { info ->
                     // Tchap: Disable cross-signing
                     val mxCrossSigningInfo = info.getOrNull()
-                    if (!vectorFeatures.isCrossSigningEnabled() && mxCrossSigningInfo != null) {
+                    if (!vectorFeatures.tchapIsCrossSigningEnabled() && mxCrossSigningInfo != null) {
                         Timber.i("Cross signing feature is disabled. This account should not have cross signing keys")
                     }
 

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -31,7 +31,6 @@ import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.withState
 import com.google.android.material.badge.BadgeDrawable
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import im.vector.app.BuildConfig
 import im.vector.app.R
 import im.vector.app.SpaceStateHandler
 import im.vector.app.core.extensions.commitTransaction
@@ -45,6 +44,7 @@ import im.vector.app.core.ui.views.CurrentCallsView
 import im.vector.app.core.ui.views.CurrentCallsViewPresenter
 import im.vector.app.core.ui.views.KeysBackupBanner
 import im.vector.app.databinding.FragmentHomeDetailBinding
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.call.SharedKnownCallsViewModel
 import im.vector.app.features.call.VectorCallActivity
 import im.vector.app.features.call.dialpad.DialPadFragment
@@ -72,6 +72,7 @@ import org.matrix.android.sdk.api.session.user.model.User
 import javax.inject.Inject
 
 class HomeDetailFragment @Inject constructor(
+        private val vectorFeatures: VectorFeatures,
         private val avatarRenderer: AvatarRenderer,
         private val colorProvider: ColorProvider,
         private val alertManager: PopupAlertManager,
@@ -170,7 +171,7 @@ class HomeDetailFragment @Inject constructor(
                     val newest = unknownDevices.firstOrNull { it.isNew }?.deviceInfo
                     if (newest != null) {
                         promptForNewUnknownDevices(uid, state, newest)
-                    } else if (BuildConfig.ENABLE_CROSS_SIGNING && olderUnverified.isNotEmpty()) {
+                    } else if (vectorFeatures.isCrossSigningEnabled() && olderUnverified.isNotEmpty()) {
                         // In this case we prompt to go to settings to review logins
                         promptToReviewChanges(uid, state, olderUnverified.map { it.deviceInfo })
                     }

--- a/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeDetailFragment.kt
@@ -171,7 +171,7 @@ class HomeDetailFragment @Inject constructor(
                     val newest = unknownDevices.firstOrNull { it.isNew }?.deviceInfo
                     if (newest != null) {
                         promptForNewUnknownDevices(uid, state, newest)
-                    } else if (vectorFeatures.isCrossSigningEnabled() && olderUnverified.isNotEmpty()) {
+                    } else if (vectorFeatures.tchapIsCrossSigningEnabled() && olderUnverified.isNotEmpty()) {
                         // In this case we prompt to go to settings to review logins
                         promptToReviewChanges(uid, state, olderUnverified.map { it.deviceInfo })
                     }

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -27,7 +27,6 @@ import com.airbnb.mvrx.Uninitialized
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import im.vector.app.BuildConfig
 import im.vector.app.R
 import im.vector.app.SpaceStateHandler
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
@@ -37,6 +36,7 @@ import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.resources.BuildMeta
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.utils.BehaviorDataSource
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.AnalyticsTracker
 import im.vector.app.features.analytics.DecryptionFailureTracker
 import im.vector.app.features.analytics.extensions.toAnalyticsJoinedRoom
@@ -120,6 +120,7 @@ import timber.log.Timber
 import java.util.concurrent.atomic.AtomicBoolean
 
 class TimelineViewModel @AssistedInject constructor(
+        private val vectorFeatures: VectorFeatures,
         @Assisted private val initialState: RoomDetailViewState,
         private val vectorPreferences: VectorPreferences,
         private val vectorDataStore: VectorDataStore,
@@ -764,9 +765,9 @@ class TimelineViewModel @AssistedInject constructor(
                     R.id.invite -> state.canInvite
                     R.id.open_matrix_apps -> false // Tchap: there are no matrix apps
                     // Tchap: check if voip is enabled
-                    R.id.voice_call -> BuildConfig.IS_VOIP_SUPPORTED && (state.isCallOptionAvailable() || state.hasActiveElementCallWidget())
+                    R.id.voice_call -> vectorFeatures.isVoipSupported() && (state.isCallOptionAvailable() || state.hasActiveElementCallWidget())
                     // Tchap: check if voip is enabled
-                    R.id.video_call -> BuildConfig.IS_VOIP_SUPPORTED &&
+                    R.id.video_call -> vectorFeatures.isVoipSupported() &&
                             (state.isCallOptionAvailable() || state.jitsiState.confId == null || state.jitsiState.hasJoined)
                     // Show Join conference button only if there is an active conf id not joined. Otherwise fallback to default video disabled. ^
                     R.id.join_conference -> !state.isCallOptionAvailable() && state.jitsiState.confId != null && !state.jitsiState.hasJoined

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/TimelineViewModel.kt
@@ -765,9 +765,9 @@ class TimelineViewModel @AssistedInject constructor(
                     R.id.invite -> state.canInvite
                     R.id.open_matrix_apps -> false // Tchap: there are no matrix apps
                     // Tchap: check if voip is enabled
-                    R.id.voice_call -> vectorFeatures.isVoipSupported() && (state.isCallOptionAvailable() || state.hasActiveElementCallWidget())
+                    R.id.voice_call -> vectorFeatures.tchapIsVoipSupported() && (state.isCallOptionAvailable() || state.hasActiveElementCallWidget())
                     // Tchap: check if voip is enabled
-                    R.id.video_call -> vectorFeatures.isVoipSupported() &&
+                    R.id.video_call -> vectorFeatures.tchapIsVoipSupported() &&
                             (state.isCallOptionAvailable() || state.jitsiState.confId == null || state.jitsiState.hasJoined)
                     // Show Join conference button only if there is an active conf id not joined. Otherwise fallback to default video disabled. ^
                     R.id.join_conference -> !state.isCallOptionAvailable() && state.jitsiState.confId != null && !state.jitsiState.hasJoined

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/CallItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/CallItemFactory.kt
@@ -147,7 +147,7 @@ class CallItemFactory @Inject constructor(
         val userOfInterest = roomSummary.toMatrixItem()
         val attributes = messageItemAttributesFactory.create(null, informationData, callback, reactionsSummaryEvents).let {
             CallTileTimelineItem.Attributes(
-                    isVoipSupported = vectorFeatures.isVoipSupported(),
+                    isVoipSupported = vectorFeatures.tchapIsVoipSupported(),
                     callId = callId,
                     callKind = callKind,
                     callStatus = callStatus,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/CallItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/CallItemFactory.kt
@@ -17,6 +17,7 @@ package im.vector.app.features.home.room.detail.timeline.factory
 
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.resources.UserPreferencesProvider
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.home.room.detail.timeline.MessageColorProvider
 import im.vector.app.features.home.room.detail.timeline.TimelineEventController
 import im.vector.app.features.home.room.detail.timeline.helper.AvatarSizeProvider
@@ -34,6 +35,7 @@ import org.matrix.android.sdk.api.util.toMatrixItem
 import javax.inject.Inject
 
 class CallItemFactory @Inject constructor(
+        private val vectorFeatures: VectorFeatures,
         private val session: Session,
         private val userPreferencesProvider: UserPreferencesProvider,
         private val messageColorProvider: MessageColorProvider,
@@ -145,6 +147,7 @@ class CallItemFactory @Inject constructor(
         val userOfInterest = roomSummary.toMatrixItem()
         val attributes = messageItemAttributesFactory.create(null, informationData, callback, reactionsSummaryEvents).let {
             CallTileTimelineItem.Attributes(
+                    isVoipSupported = vectorFeatures.isVoipSupported(),
                     callId = callId,
                     callKind = callKind,
                     callStatus = callStatus,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/WidgetItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/WidgetItemFactory.kt
@@ -78,7 +78,7 @@ class WidgetItemFactory @Inject constructor(
             CallTileTimelineItem.CallStatus.ENDED
         }
         val attributes = CallTileTimelineItem.Attributes(
-                isVoipSupported = vectorFeatures.isVoipSupported(),
+                isVoipSupported = vectorFeatures.tchapIsVoipSupported(),
                 callId = jitsiWidgetEventsGroup.callId,
                 callKind = CallTileTimelineItem.CallKind.CONFERENCE,
                 callStatus = callStatus,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/WidgetItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/WidgetItemFactory.kt
@@ -18,6 +18,7 @@ package im.vector.app.features.home.room.detail.timeline.factory
 
 import im.vector.app.core.epoxy.VectorEpoxyModel
 import im.vector.app.core.resources.UserPreferencesProvider
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.detail.timeline.MessageColorProvider
 import im.vector.app.features.home.room.detail.timeline.helper.AvatarSizeProvider
@@ -32,6 +33,7 @@ import org.matrix.android.sdk.api.util.toMatrixItem
 import javax.inject.Inject
 
 class WidgetItemFactory @Inject constructor(
+        private val vectorFeatures: VectorFeatures,
         private val informationDataFactory: MessageInformationDataFactory,
         private val noticeItemFactory: NoticeItemFactory,
         private val avatarSizeProvider: AvatarSizeProvider,
@@ -76,6 +78,7 @@ class WidgetItemFactory @Inject constructor(
             CallTileTimelineItem.CallStatus.ENDED
         }
         val attributes = CallTileTimelineItem.Attributes(
+                isVoipSupported = vectorFeatures.isVoipSupported(),
                 callId = jitsiWidgetEventsGroup.callId,
                 callKind = CallTileTimelineItem.CallKind.CONFERENCE,
                 callStatus = callStatus,

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/CallTileTimelineItem.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/item/CallTileTimelineItem.kt
@@ -28,7 +28,6 @@ import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import com.airbnb.epoxy.EpoxyAttribute
 import com.airbnb.epoxy.EpoxyModelClass
-import im.vector.app.BuildConfig
 import im.vector.app.R
 import im.vector.app.core.epoxy.ClickListener
 import im.vector.app.core.epoxy.onClick
@@ -225,10 +224,9 @@ abstract class CallTileTimelineItem : AbsBaseMessageItem<CallTileTimelineItem.Ho
     }
 
     private fun renderCallSupportState(holder: Holder) {
-        val isCallSupported = BuildConfig.IS_VOIP_SUPPORTED
-        val error = if (!isCallSupported) holder.resources.getString(R.string.tchap_call_not_supported) else null
-        holder.acceptView.isEnabled = isCallSupported
-        holder.rejectView.isEnabled = isCallSupported
+        val error = if (!attributes.isVoipSupported) holder.resources.getString(R.string.tchap_call_not_supported) else null
+        holder.acceptView.isEnabled = attributes.isVoipSupported
+        holder.rejectView.isEnabled = attributes.isVoipSupported
         holder.errorView.setTextOrHide(error)
     }
 
@@ -262,6 +260,7 @@ abstract class CallTileTimelineItem : AbsBaseMessageItem<CallTileTimelineItem.Ho
     }
 
     data class Attributes(
+            val isVoipSupported: Boolean,
             val callId: String,
             val callKind: CallKind,
             val callStatus: CallStatus,

--- a/vector/src/main/java/im/vector/app/features/login/LoginResetPasswordFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginResetPasswordFragment.kt
@@ -24,12 +24,12 @@ import androidx.lifecycle.lifecycleScope
 import com.airbnb.mvrx.Fail
 import com.airbnb.mvrx.Loading
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import im.vector.app.BuildConfig
 import im.vector.app.R
 import im.vector.app.core.extensions.hideKeyboard
 import im.vector.app.core.extensions.hidePassword
 import im.vector.app.core.extensions.isEmail
 import im.vector.app.databinding.FragmentLoginResetPasswordBinding
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.plan.MobileScreen
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
@@ -41,7 +41,9 @@ import javax.inject.Inject
 /**
  * In this screen, the user is asked for email and new password to reset his password.
  */
-class LoginResetPasswordFragment @Inject constructor() : AbstractLoginFragment<FragmentLoginResetPasswordBinding>() {
+class LoginResetPasswordFragment @Inject constructor(
+        private val vectorFeatures: VectorFeatures,
+) : AbstractLoginFragment<FragmentLoginResetPasswordBinding>() {
 
     // Show warning only once
     private var showWarning = true
@@ -62,13 +64,13 @@ class LoginResetPasswordFragment @Inject constructor() : AbstractLoginFragment<F
 
         loginViewModel.observeViewEvents { loginViewEvents ->
             when (loginViewEvents) {
-                LoginViewEvents.OnLoginFlowRetrieved     ->
+                LoginViewEvents.OnLoginFlowRetrieved ->
                     loginViewModel.handle(LoginAction.CheckPasswordPolicy(views.passwordField.text.toString()))
-                LoginViewEvents.OnPasswordValidated      ->
+                LoginViewEvents.OnPasswordValidated ->
                     submit()
                 is LoginViewEvents.OnHomeServerRetrieved ->
                     updateHomeServer(loginViewEvents.hs)
-                else                                     -> Unit // This is handled by the Activity
+                else -> Unit // This is handled by the Activity
             }
         }
     }
@@ -96,7 +98,7 @@ class LoginResetPasswordFragment @Inject constructor() : AbstractLoginFragment<F
 
         if (showWarning) {
             showWarning = false
-            val message = if (BuildConfig.IS_KEY_BACKUP_SUPPORTED) {
+            val message = if (vectorFeatures.isKeyBackupEnabled()) {
                 R.string.login_reset_password_warning_content
             } else {
                 R.string.tchap_login_reset_password_warning_content

--- a/vector/src/main/java/im/vector/app/features/login/LoginResetPasswordFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/login/LoginResetPasswordFragment.kt
@@ -98,7 +98,7 @@ class LoginResetPasswordFragment @Inject constructor(
 
         if (showWarning) {
             showWarning = false
-            val message = if (vectorFeatures.isKeyBackupEnabled()) {
+            val message = if (vectorFeatures.tchapIsKeyBackupEnabled()) {
                 R.string.login_reset_password_warning_content
             } else {
                 R.string.tchap_login_reset_password_warning_content

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
@@ -333,7 +333,7 @@ class VectorSettingsSecurityPrivacyFragment @Inject constructor(
 
     // Todo this should be refactored and use same state as 4S section
     private fun refreshXSigningStatus() {
-        if (vectorFeatures.isCrossSigningEnabled()) {
+        if (vectorFeatures.tchapIsCrossSigningEnabled()) {
             val crossSigningKeys = session.cryptoService().crossSigningService().getMyCrossSigningKeys()
             val xSigningIsEnableInAccount = crossSigningKeys != null
             val xSigningKeysAreTrusted = session.cryptoService().crossSigningService().checkUserTrust(session.myUserId).isVerified()

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
@@ -200,7 +200,7 @@ class VectorSettingsSecurityPrivacyFragment @Inject constructor(
     private fun refresh4SSection(info: SecretsSynchronisationInfo) {
         // it's a lot of if / else if / else
         // But it's not yet clear how to manage all cases
-        if (!vectorFeatures.isKeyBackupEnabled() || !info.isCrossSigningEnabled) {
+        if (!vectorFeatures.tchapIsKeyBackupEnabled() || !info.isCrossSigningEnabled) {
             // Key backup is not supported or there is not cross signing, so we can remove the section
             secureBackupCategory.isVisible = false
         } else {

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsSecurityPrivacyFragment.kt
@@ -34,7 +34,6 @@ import androidx.preference.SwitchPreference
 import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.mvrx.fragmentViewModel
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import im.vector.app.BuildConfig
 import im.vector.app.R
 import im.vector.app.core.di.ActiveSessionHolder
 import im.vector.app.core.dialogs.ExportKeysDialog
@@ -51,6 +50,7 @@ import im.vector.app.core.utils.copyToClipboard
 import im.vector.app.core.utils.openFileSelection
 import im.vector.app.core.utils.toast
 import im.vector.app.databinding.DialogImportE2eKeysBinding
+import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.AnalyticsConfig
 import im.vector.app.features.analytics.plan.MobileScreen
 import im.vector.app.features.analytics.ui.consent.AnalyticsConsentViewActions
@@ -80,6 +80,7 @@ import org.matrix.android.sdk.api.session.crypto.model.DevicesListResponse
 import javax.inject.Inject
 
 class VectorSettingsSecurityPrivacyFragment @Inject constructor(
+        private val vectorFeatures: VectorFeatures,
         private val activeSessionHolder: ActiveSessionHolder,
         private val pinCodeStore: PinCodeStore,
         private val keysExporter: KeysExporter,
@@ -199,8 +200,7 @@ class VectorSettingsSecurityPrivacyFragment @Inject constructor(
     private fun refresh4SSection(info: SecretsSynchronisationInfo) {
         // it's a lot of if / else if / else
         // But it's not yet clear how to manage all cases
-        val isKeyBackupSupported: Boolean = BuildConfig.IS_KEY_BACKUP_SUPPORTED
-        if (!isKeyBackupSupported || !info.isCrossSigningEnabled) {
+        if (!vectorFeatures.isKeyBackupEnabled() || !info.isCrossSigningEnabled) {
             // Key backup is not supported or there is not cross signing, so we can remove the section
             secureBackupCategory.isVisible = false
         } else {
@@ -333,7 +333,7 @@ class VectorSettingsSecurityPrivacyFragment @Inject constructor(
 
     // Todo this should be refactored and use same state as 4S section
     private fun refreshXSigningStatus() {
-        if (BuildConfig.ENABLE_CROSS_SIGNING) {
+        if (vectorFeatures.isCrossSigningEnabled()) {
             val crossSigningKeys = session.cryptoService().crossSigningService().getMyCrossSigningKeys()
             val xSigningIsEnableInAccount = crossSigningKeys != null
             val xSigningKeysAreTrusted = session.cryptoService().crossSigningService().checkUserTrust(session.myUserId).isVerified()

--- a/vector/src/main/java/im/vector/app/features/workers/signout/ServerBackupStatusViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/workers/signout/ServerBackupStatusViewModel.kt
@@ -24,12 +24,12 @@ import com.airbnb.mvrx.Uninitialized
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import im.vector.app.BuildConfig
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.EmptyAction
 import im.vector.app.core.platform.EmptyViewEvents
 import im.vector.app.core.platform.VectorViewModel
+import im.vector.app.features.VectorFeatures
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -65,6 +65,7 @@ sealed class BannerState {
 
 class ServerBackupStatusViewModel @AssistedInject constructor(
         @Assisted initialState: ServerBackupStatusViewState,
+        vectorFeatures: VectorFeatures,
         private val session: Session
 ) :
         VectorViewModel<ServerBackupStatusViewState, EmptyAction, EmptyViewEvents>(initialState), KeysBackupStateListener {
@@ -84,7 +85,7 @@ class ServerBackupStatusViewModel @AssistedInject constructor(
 
     init {
         // if key backup is not supported, do nothing
-        if (BuildConfig.IS_KEY_BACKUP_SUPPORTED) {
+        if (vectorFeatures.isKeyBackupEnabled()) {
             init()
         }
     }

--- a/vector/src/main/java/im/vector/app/features/workers/signout/ServerBackupStatusViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/workers/signout/ServerBackupStatusViewModel.kt
@@ -85,7 +85,7 @@ class ServerBackupStatusViewModel @AssistedInject constructor(
 
     init {
         // if key backup is not supported, do nothing
-        if (vectorFeatures.isKeyBackupEnabled()) {
+        if (vectorFeatures.tchapIsKeyBackupEnabled()) {
             init()
         }
     }

--- a/vector/src/main/java/im/vector/app/features/workers/signout/SignoutCheckViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/workers/signout/SignoutCheckViewModel.kt
@@ -23,19 +23,21 @@ import com.airbnb.mvrx.MavericksState
 import com.airbnb.mvrx.MavericksViewModelFactory
 import com.airbnb.mvrx.Success
 import com.airbnb.mvrx.Uninitialized
+import com.airbnb.mvrx.ViewModelContext
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import im.vector.app.BuildConfig
 import im.vector.app.core.di.MavericksAssistedViewModelFactory
 import im.vector.app.core.di.hiltMavericksViewModelFactory
 import im.vector.app.core.platform.EmptyViewEvents
+import im.vector.app.core.platform.VectorBaseActivity
 import im.vector.app.core.platform.VectorViewModel
 import im.vector.app.core.platform.VectorViewModelAction
 import im.vector.app.features.crypto.keys.KeysExporter
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
+import org.matrix.android.sdk.api.extensions.orFalse
 import org.matrix.android.sdk.api.session.Session
 import org.matrix.android.sdk.api.session.crypto.crosssigning.MASTER_KEY_SSSS_NAME
 import org.matrix.android.sdk.api.session.crypto.crosssigning.SELF_SIGNING_KEY_SSSS_NAME
@@ -51,7 +53,7 @@ data class SignoutCheckViewState(
         val crossSigningSetupAllKeysKnown: Boolean = false,
         val keysBackupState: KeysBackupState = KeysBackupState.Unknown,
         val hasBeenExportedToFile: Async<Boolean> = Uninitialized,
-        val isKeyBackupSupported: Boolean = BuildConfig.IS_KEY_BACKUP_SUPPORTED
+        val isKeyBackupSupported: Boolean = false
 ) : MavericksState
 
 class SignoutCheckViewModel @AssistedInject constructor(
@@ -70,7 +72,13 @@ class SignoutCheckViewModel @AssistedInject constructor(
         override fun create(initialState: SignoutCheckViewState): SignoutCheckViewModel
     }
 
-    companion object : MavericksViewModelFactory<SignoutCheckViewModel, SignoutCheckViewState> by hiltMavericksViewModelFactory()
+    // Tchap: init viewState with key backup
+    companion object : MavericksViewModelFactory<SignoutCheckViewModel, SignoutCheckViewState> by hiltMavericksViewModelFactory() {
+        override fun initialState(viewModelContext: ViewModelContext): SignoutCheckViewState? {
+            val isKeyBackupEnabled = (viewModelContext.activity as? VectorBaseActivity<*>)?.vectorFeatures?.isKeyBackupEnabled().orFalse()
+            return SignoutCheckViewState(isKeyBackupSupported = isKeyBackupEnabled)
+        }
+    }
 
     init {
         withState { state ->

--- a/vector/src/main/java/im/vector/app/features/workers/signout/SignoutCheckViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/workers/signout/SignoutCheckViewModel.kt
@@ -75,7 +75,7 @@ class SignoutCheckViewModel @AssistedInject constructor(
     // Tchap: init viewState with key backup
     companion object : MavericksViewModelFactory<SignoutCheckViewModel, SignoutCheckViewState> by hiltMavericksViewModelFactory() {
         override fun initialState(viewModelContext: ViewModelContext): SignoutCheckViewState? {
-            val isKeyBackupEnabled = (viewModelContext.activity as? VectorBaseActivity<*>)?.vectorFeatures?.isKeyBackupEnabled().orFalse()
+            val isKeyBackupEnabled = (viewModelContext.activity as? VectorBaseActivity<*>)?.vectorFeatures?.tchapIsKeyBackupEnabled().orFalse()
             return SignoutCheckViewState(isKeyBackupSupported = isKeyBackupEnabled)
         }
     }

--- a/vector/src/main/res/xml/vector_settings_advanced_settings.xml
+++ b/vector/src/main/res/xml/vector_settings_advanced_settings.xml
@@ -4,7 +4,7 @@
 
     <im.vector.app.core.preference.VectorPreferenceCategory
         android:title="@string/settings_developer_mode"
-        app:isPreferenceVisible="@bool/developer_mode_visible">
+        app:isPreferenceVisible="@bool/tchap_settings_advanced_developer_mode_visible">
 
         <im.vector.app.core.preference.VectorSwitchPreference
             android:defaultValue="false"
@@ -85,7 +85,7 @@
     <im.vector.app.core.preference.VectorPreferenceCategory
         android:dependency="SETTINGS_DEVELOPER_MODE_PREFERENCE_KEY"
         android:title="@string/settings_dev_tools"
-        app:isPreferenceVisible="@bool/developer_mode_visible">
+        app:isPreferenceVisible="@bool/tchap_settings_advanced_developer_mode_visible">
 
         <im.vector.app.core.preference.VectorPreference
             android:persistent="false"

--- a/vector/src/main/res/xml/vector_settings_labs.xml
+++ b/vector/src/main/res/xml/vector_settings_labs.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<androidx.preference.PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!--<im.vector.app.core.preference.VectorPreferenceCategory-->
     <!--android:key="SETTINGS_LABS_PREFERENCE_KEY"-->
@@ -72,7 +71,7 @@
         android:title="@string/labs_auto_report_uisi" />
 
     <im.vector.app.core.preference.VectorSwitchPreference
-        android:defaultValue="@bool/enable_location_sharing"
+        android:defaultValue="@bool/tchap_settings_labs_enable_location_sharing"
         android:key="SETTINGS_LABS_RENDER_LOCATIONS_IN_TIMELINE"
         android:summary="@string/labs_enable_live_location_summary"
         android:title="@string/labs_enable_live_location" />

--- a/vector/src/main/res/xml/vector_settings_preferences.xml
+++ b/vector/src/main/res/xml/vector_settings_preferences.xml
@@ -32,10 +32,10 @@
 
     <im.vector.app.core.preference.VectorPreferenceCategory
         android:title="@string/spaces"
-        app:isPreferenceVisible="@bool/show_spaces">
+        app:isPreferenceVisible="@bool/tchap_settings_spaces_visible">
 
         <im.vector.app.core.preference.VectorSwitchPreference
-            android:defaultValue="@bool/spaces_show_all_in_home"
+            android:defaultValue="@bool/tchap_settings_spaces_show_all_room_in_home_default"
             android:key="SETTINGS_PREF_SPACE_SHOW_ALL_ROOM_IN_HOME"
             android:summary="@string/all_rooms_youre_in_will_be_shown_in_home"
             android:title="@string/preference_show_all_rooms_in_home" />

--- a/vector/src/main/res/xml/vector_settings_root.xml
+++ b/vector/src/main/res/xml/vector_settings_root.xml
@@ -24,7 +24,7 @@
         android:icon="@drawable/ic_settings_root_call"
         android:title="@string/preference_voice_and_video"
         app:fragment="im.vector.app.features.settings.VectorSettingsVoiceVideoFragment"
-        app:isPreferenceVisible="@bool/is_voip_supported" />
+        app:isPreferenceVisible="@bool/tchap_is_voip_supported" />
 
     <im.vector.app.core.preference.VectorPreference
         android:icon="@drawable/ic_settings_root_security_privacy"

--- a/vector/src/main/res/xml/vector_settings_root.xml
+++ b/vector/src/main/res/xml/vector_settings_root.xml
@@ -36,7 +36,7 @@
         android:icon="@drawable/ic_settings_root_labs"
         android:title="@string/room_settings_labs_pref_title"
         app:fragment="im.vector.app.features.settings.VectorSettingsLabsFragment"
-        app:isPreferenceVisible="@bool/labs_settings_visible" />
+        app:isPreferenceVisible="@bool/tchap_settings_root_labs_visible" />
 
     <im.vector.app.core.preference.VectorPreference
         android:icon="@drawable/ic_settings_root_advanced"

--- a/vector/src/main/res/xml/vector_settings_security_privacy.xml
+++ b/vector/src/main/res/xml/vector_settings_security_privacy.xml
@@ -22,7 +22,7 @@
             android:key="SETTINGS_ENCRYPTION_CROSS_SIGNING_PREFERENCE_KEY"
             android:persistent="false"
             android:title="@string/encryption_information_cross_signing_state"
-            app:isPreferenceVisible="@bool/enable_cross_signing"
+            app:isPreferenceVisible="@bool/tchap_is_cross_signing_enabled"
             app:fragment="im.vector.app.features.settings.crosssigning.CrossSigningSettingsFragment"
             tools:icon="@drawable/ic_shield_trusted"
             tools:summary="@string/encryption_information_dg_xsigning_complete" />

--- a/vector/src/release/java/im/vector/app/core/di/FeaturesModule.kt
+++ b/vector/src/release/java/im/vector/app/core/di/FeaturesModule.kt
@@ -20,6 +20,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import im.vector.app.core.resources.BooleanProvider
 import im.vector.app.features.DefaultVectorFeatures
 import im.vector.app.features.DefaultVectorOverrides
 import im.vector.app.features.VectorFeatures
@@ -30,8 +31,8 @@ import im.vector.app.features.VectorOverrides
 object FeaturesModule {
 
     @Provides
-    fun providesFeatures(): VectorFeatures {
-        return DefaultVectorFeatures()
+    fun providesFeatures(booleanProvider: BooleanProvider): VectorFeatures {
+        return DefaultVectorFeatures(booleanProvider)
     }
 
     @Provides

--- a/vector/src/test/java/im/vector/app/test/fakes/FakeVectorFeatures.kt
+++ b/vector/src/test/java/im/vector/app/test/fakes/FakeVectorFeatures.kt
@@ -16,12 +16,11 @@
 
 package im.vector.app.test.fakes
 
-import im.vector.app.features.DefaultVectorFeatures
 import im.vector.app.features.VectorFeatures
 import io.mockk.every
-import io.mockk.spyk
+import io.mockk.mockk
 
-class FakeVectorFeatures : VectorFeatures by spyk<DefaultVectorFeatures>() {
+class FakeVectorFeatures constructor(vectorFeatures: VectorFeatures = mockk()) : VectorFeatures by vectorFeatures {
 
     fun givenPersonalisationEnabled() {
         every { isOnboardingPersonalizeEnabled() } returns true


### PR DESCRIPTION
Element avoids the direct usage of BuildConfig fields since the version v1.4.32 ([related PR](https://github.com/vector-im/element-android/pull/6517))
The goal of this PR is to do the same for Tchap by moving all the build configs and resource configs to the dedicated module `vector-configs`.

Doing that, we have more flexibility to override some config in the unit tests and centralize it in a single place (making it easier to track)