### PR TITLE
Activate the content scanner for audio files

### DIFF
--- a/changelog.d/780.misc
+++ b/changelog.d/780.misc
@@ -1,0 +1,1 @@
+Activate the antivirus for audio files

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/factory/MessageItemFactory.kt
@@ -289,6 +289,9 @@ class MessageItemFactory @Inject constructor(
                 .contentDownloadStateTrackerBinder(contentDownloadStateTrackerBinder)
                 .highlighted(highlight)
                 .leftGuideline(avatarSizeProvider.leftGuideline)
+                // Tchap: Use for the Antivirus
+                .elementToDecrypt(messageContent.encryptedFileInfo?.toElementToDecrypt())
+                .contentScannerStateTracker(contentScannerStateTracker)
     }
 
     private fun getAudioFileUrl(
@@ -347,6 +350,9 @@ class MessageItemFactory @Inject constructor(
                 .contentDownloadStateTrackerBinder(contentDownloadStateTrackerBinder)
                 .highlighted(highlight)
                 .leftGuideline(avatarSizeProvider.leftGuideline)
+                // Tchap: Use for the Antivirus
+                .elementToDecrypt(messageContent.encryptedFileInfo?.toElementToDecrypt())
+                .contentScannerStateTracker(contentScannerStateTracker)
     }
 
     private fun buildVerificationRequestMessageItem(

--- a/vector/src/main/res/layout/item_timeline_event_audio_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_audio_stub.xml
@@ -94,6 +94,16 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
+    <TextView
+        android:id="@+id/messageFileAvText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:drawablePadding="4dp"
+        android:visibility="gone"
+        tools:drawableLeft="@drawable/ic_av_checked"
+        tools:text="@string/antivirus_infected"
+        tools:visibility="visible" />
+
     <include
         android:id="@+id/messageFileUploadProgressLayout"
         layout="@layout/media_upload_download_progress_layout"

--- a/vector/src/main/res/layout/item_timeline_event_voice_stub.xml
+++ b/vector/src/main/res/layout/item_timeline_event_voice_stub.xml
@@ -55,6 +55,16 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
+    <TextView
+        android:id="@+id/messageFileAvText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:drawablePadding="4dp"
+        android:visibility="gone"
+        tools:drawableLeft="@drawable/ic_av_checked"
+        tools:text="@string/antivirus_infected"
+        tools:visibility="visible" />
+
     <include
         android:id="@+id/messageFileUploadProgressLayout"
         layout="@layout/media_upload_download_progress_layout"


### PR DESCRIPTION
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Activate the antivirus for audio files and voice messages
Show an indicator in the timeline about the scan result like for the other media
Disable clicks if the media is infected

## Motivation and context

#780 

## Screenshots / GIFs

Trusted:

https://user-images.githubusercontent.com/11990514/206188940-c1b08d64-ed91-4296-a336-3a28581bff00.mp4

Infected (fake):

https://user-images.githubusercontent.com/11990514/206189000-ffd6a70f-a55a-4a4d-b4fc-94cb1ab1de60.mp4


## Tests

- Send voice messages and mp3 files in a room
- Verify that the files are marked as not infected and can be played
- In the code, invert the condition in `MessageAudioItem.Holder` and `MessageVoiceItem.Holder`
- Test again and verify that the files are marked as infected, all the actions should be blocked

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [TCHAP_CHANGES.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/TCHAP_CHANGES.md)
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android-v2/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
