### PR TITLE
Fix crash on open the "access by link" screen

### DIFF
--- a/changelog.d/776.bugfix
+++ b/changelog.d/776.bugfix
@@ -1,0 +1,1 @@
+Crash on open the "access by link" screen

--- a/vector/src/main/java/fr/gouv/tchap/features/roomprofile/settings/linkaccess/TchapRoomLinkAccessFragment.kt
+++ b/vector/src/main/java/fr/gouv/tchap/features/roomprofile/settings/linkaccess/TchapRoomLinkAccessFragment.kt
@@ -24,6 +24,7 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.airbnb.mvrx.fragmentViewModel
 import com.airbnb.mvrx.withState
+import dagger.hilt.android.AndroidEntryPoint
 import fr.gouv.tchap.features.roomprofile.settings.linkaccess.detail.TchapRoomLinkAccessBottomSheet
 import fr.gouv.tchap.features.roomprofile.settings.linkaccess.detail.TchapRoomLinkAccessBottomSheetSharedAction
 import fr.gouv.tchap.features.roomprofile.settings.linkaccess.detail.TchapRoomLinkAccessBottomSheetSharedActionViewModel
@@ -40,12 +41,13 @@ import kotlinx.coroutines.flow.onEach
 import org.matrix.android.sdk.api.util.toMatrixItem
 import javax.inject.Inject
 
-class TchapRoomLinkAccessFragment @Inject constructor(
-        val viewModelFactory: TchapRoomLinkAccessViewModel.Factory,
-        val controller: TchapRoomLinkAccessController,
-        private val avatarRenderer: AvatarRenderer
-) : VectorBaseFragment<FragmentRoomSettingGenericBinding>(),
+@AndroidEntryPoint
+class TchapRoomLinkAccessFragment : VectorBaseFragment<FragmentRoomSettingGenericBinding>(),
         TchapRoomLinkAccessController.InteractionListener {
+
+    @Inject lateinit var viewModelFactory: TchapRoomLinkAccessViewModel.Factory
+    @Inject lateinit var controller: TchapRoomLinkAccessController
+    @Inject lateinit var avatarRenderer: AvatarRenderer
 
     private val viewModel: TchapRoomLinkAccessViewModel by fragmentViewModel()
     private lateinit var sharedActionViewModel: TchapRoomLinkAccessBottomSheetSharedActionViewModel


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Fix issue #776 

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request updates [TCHAP_CHANGES.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/TCHAP_CHANGES.md)
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android-v2/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
