### PR TITLE
Remove the ability to install an app from Tchap

### DIFF
--- a/vector/src/main/AndroidManifest.xml
+++ b/vector/src/main/AndroidManifest.xml
@@ -35,7 +35,9 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
     <!-- To be able to install APK from the application -->
+    <!-- Tchap: Remove the ability to install an app from Tchap (https://github.com/tchapgouv/tchap-android/issues/832)
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    -->
 
     <!-- Location Sharing -->
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />


### PR DESCRIPTION
Close #832

<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [x] Technical
- [ ] Other :

## Content

Remove the ability to install an app from Tchap

## Motivation and context

Installing an APK from Tchap is a security risk for users