### PR TITLE
Nouvel icône à propos

### DIFF
--- a/vector/src/main/res/drawable/ic_settings_root_help_info.xml
+++ b/vector/src/main/res/drawable/ic_settings_root_help_info.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="25dp"
+    android:height="25dp"
+    android:viewportWidth="25"
+    android:viewportHeight="25">
+  <path
+      android:pathData="M12.5,22.5C18.023,22.5 22.5,18.023 22.5,12.5C22.5,6.977 18.023,2.5 12.5,2.5C6.977,2.5 2.5,6.977 2.5,12.5C2.5,18.023 6.977,22.5 12.5,22.5ZM13.475,17.748H11.316V10.832H13.475V17.748ZM13.648,8.137C13.648,8.84 13.087,9.413 12.401,9.413C11.709,9.413 11.148,8.84 11.148,8.137C11.148,7.427 11.709,6.854 12.401,6.854C13.087,6.854 13.648,7.427 13.648,8.137Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/vector/src/main/res/xml/vector_settings_root.xml
+++ b/vector/src/main/res/xml/vector_settings_root.xml
@@ -51,7 +51,7 @@
         android:title="@string/preference_help_title" />
 
     <im.vector.app.core.preference.VectorPreference
-        android:icon="@drawable/ic_settings_root_help_about"
+        android:icon="@drawable/ic_settings_root_help_info"
         android:title="@string/preference_root_help_about"
         app:fragment="im.vector.app.features.settings.VectorSettingsHelpAboutFragment"
         app:isPreferenceVisible="@bool/settings_root_help_about_visible" />


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other : Modification graphique

## Content

Du fait d'une nouvelle entrée dans le menu latéral, nouvelle icône pour la rubrique A propos

## Screenshots / GIFs

![Screenshot_20230428_150234](https://user-images.githubusercontent.com/16257004/235156969-59003697-bc51-4f8f-8718-b957be726898.png)


## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s): Android 13

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [x] UI change has been tested on both light and dark themes
- [x] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request updates [TCHAP_CHANGES.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/TCHAP_CHANGES.md)
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android-v2/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
