### PR TITLE
[Badge messages non lus] Les badges de messages non-lus n'apparaissen…

### DIFF
--- a/TCHAP_CHANGES.md
+++ b/TCHAP_CHANGES.md
@@ -1,3 +1,17 @@
+Changes in Tchap 2.8.1 (2023-06-01)
+===================================
+
+Bugfixes 🐛
+----------
+ - [Badge messages non lus] Les badges de messages non-lus n'apparaissent plus en v2.8.3 #924 ([#924](https://github.com/tchapgouv/tchap-android-v2/issues/924))
+
+Other changes
+-------------
+ - Rendre la FAQ plus visible et accessible ([#913](https://github.com/tchapgouv/tchap-android-v2/issues/913))
+ - Masquer la pastille de non lus au dessus du bouton nouveau message ([#917](https://github.com/tchapgouv/tchap-android-v2/issues/917))
+ - Android Rebase Element 1.5.32 (#919) ([#919](https://github.com/tchapgouv/tchap-android-v2/issues/919))
+
+
 Changes in Tchap 2.8.1 (2023-04-18)
 ===================================
 

--- a/changelog.d/913.misc
+++ b/changelog.d/913.misc
@@ -1,1 +1,0 @@
-Rendre la FAQ plus visible et accessible

--- a/changelog.d/917.misc
+++ b/changelog.d/917.misc
@@ -1,1 +1,0 @@
-Masquer la pastille de non lus au dessus du bouton nouveau message

--- a/changelog.d/919.misc
+++ b/changelog.d/919.misc
@@ -1,1 +1,0 @@
-Android Rebase Element 1.5.32 (#919)

--- a/vector-app/build.gradle
+++ b/vector-app/build.gradle
@@ -37,7 +37,7 @@ ext.versionMinor = 8
 // Note: even values are reserved for regular release, odd values for hotfix release.
 // When creating a hotfix, you should decrease the value, since the current value
 // is the value for the next regular release.
-ext.versionPatch = 1
+ext.versionPatch = 4
 
 static def getGitTimestamp() {
     def cmd = 'git show -s --format=%ct'

--- a/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/home/NewHomeDetailFragment.kt
@@ -198,9 +198,10 @@ class NewHomeDetailFragment :
                     invalidateOptionsMenu()
                 }
 
-        newHomeDetailViewModel.onEach { viewState ->
-            refreshUnreadCounterBadge(viewState.spacesNotificationCounterBadgeState)
-        }
+        // Tchap : hide unread count for space (shown above "+" button on main view)
+//        newHomeDetailViewModel.onEach { viewState ->
+//            refreshUnreadCounterBadge(viewState.spacesNotificationCounterBadgeState)
+//        }
     }
 
     private fun setupObservers() {

--- a/vector/src/main/java/im/vector/app/features/home/room/list/UnreadCounterBadgeView.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/list/UnreadCounterBadgeView.kt
@@ -43,8 +43,7 @@ class UnreadCounterBadgeView : MaterialTextView {
             if (count == 0) {
                 visibility = View.INVISIBLE
             } else {
-                // Tcahp : count remains invisible
-                visibility = View.INVISIBLE
+                visibility = View.VISIBLE
                 val bgRes = if (highlighted) {
                     R.drawable.bg_unread_highlight
                 } else {


### PR DESCRIPTION
Fix #924

Le fix précédent avaient rendu invisibles tous les badges "non lus".

Celui-ci réactive les badges "non-lus" mais masque le badge global de "non lus" par espace.