### PR TITLE
Remove Push Notification diagnostic test on server name

### DIFF
--- a/changelog.d/950.fix
+++ b/changelog.d/950.fix
@@ -1,0 +1,1 @@
+Correction du test de Push Notification non adapté à Tchap #950

--- a/vector-app/src/fdroid/java/im/vector/app/push/fcm/FdroidNotificationTroubleshootTestManagerFactory.kt
+++ b/vector-app/src/fdroid/java/im/vector/app/push/fcm/FdroidNotificationTroubleshootTestManagerFactory.kt
@@ -29,7 +29,7 @@ import im.vector.app.features.settings.troubleshoot.TestCurrentUnifiedPushDistri
 import im.vector.app.features.settings.troubleshoot.TestDeviceSettings
 import im.vector.app.features.settings.troubleshoot.TestEndpointAsTokenRegistration
 import im.vector.app.features.settings.troubleshoot.TestNotification
-import im.vector.app.features.settings.troubleshoot.TestPushFromPushGateway
+// import im.vector.app.features.settings.troubleshoot.TestPushFromPushGateway // Tchap : remove
 import im.vector.app.features.settings.troubleshoot.TestPushRulesSettings
 import im.vector.app.features.settings.troubleshoot.TestSystemSettings
 import im.vector.app.features.settings.troubleshoot.TestUnifiedPushEndpoint
@@ -47,7 +47,7 @@ class FdroidNotificationTroubleshootTestManagerFactory @Inject constructor(
         private val testUnifiedPushEndpoint: TestUnifiedPushEndpoint,
         private val testAvailableUnifiedPushDistributors: TestAvailableUnifiedPushDistributors,
         private val testEndpointAsTokenRegistration: TestEndpointAsTokenRegistration,
-        private val testPushFromPushGateway: TestPushFromPushGateway,
+        // private val testPushFromPushGateway: TestPushFromPushGateway, // Tchap : remove
         private val testAutoStartBoot: TestAutoStartBoot,
         private val testBackgroundRestrictions: TestBackgroundRestrictions,
         private val testBatteryOptimization: TestBatteryOptimization,
@@ -73,7 +73,7 @@ class FdroidNotificationTroubleshootTestManagerFactory @Inject constructor(
             mgr.addTest(testUnifiedPushGateway)
             mgr.addTest(testUnifiedPushEndpoint)
             mgr.addTest(testEndpointAsTokenRegistration)
-            mgr.addTest(testPushFromPushGateway)
+//            mgr.addTest(testPushFromPushGateway) // Tchap : remove
         }
         mgr.addTest(testNotification)
         return mgr

--- a/vector-app/src/gplay/java/im/vector/app/push/fcm/GoogleNotificationTroubleshootTestManagerFactory.kt
+++ b/vector-app/src/gplay/java/im/vector/app/push/fcm/GoogleNotificationTroubleshootTestManagerFactory.kt
@@ -26,7 +26,7 @@ import im.vector.app.features.settings.troubleshoot.TestCurrentUnifiedPushDistri
 import im.vector.app.features.settings.troubleshoot.TestDeviceSettings
 import im.vector.app.features.settings.troubleshoot.TestEndpointAsTokenRegistration
 import im.vector.app.features.settings.troubleshoot.TestNotification
-import im.vector.app.features.settings.troubleshoot.TestPushFromPushGateway
+// import im.vector.app.features.settings.troubleshoot.TestPushFromPushGateway // Tchap : remove
 import im.vector.app.features.settings.troubleshoot.TestPushRulesSettings
 import im.vector.app.features.settings.troubleshoot.TestSystemSettings
 import im.vector.app.features.settings.troubleshoot.TestUnifiedPushEndpoint
@@ -50,7 +50,7 @@ class GoogleNotificationTroubleshootTestManagerFactory @Inject constructor(
         private val testUnifiedPushEndpoint: TestUnifiedPushEndpoint,
         private val testAvailableUnifiedPushDistributors: TestAvailableUnifiedPushDistributors,
         private val testEndpointAsTokenRegistration: TestEndpointAsTokenRegistration,
-        private val testPushFromPushGateway: TestPushFromPushGateway,
+        // private val testPushFromPushGateway: TestPushFromPushGateway, // Tchap : remove
         private val testNotification: TestNotification,
         private val vectorFeatures: VectorFeatures,
 ) : NotificationTroubleshootTestManagerFactory {
@@ -75,7 +75,7 @@ class GoogleNotificationTroubleshootTestManagerFactory @Inject constructor(
             mgr.addTest(testUnifiedPushEndpoint)
             mgr.addTest(testEndpointAsTokenRegistration)
         }
-        mgr.addTest(testPushFromPushGateway)
+       // mgr.addTest(testPushFromPushGateway) // Tchap : remove
         mgr.addTest(testNotification)
         return mgr
     }


### PR DESCRIPTION
Fix #950 

Suppression du test de disponibilité du serveur de Push notification basé sur le nom de serveur, non exposé au public dans le cas de Tchap.