### PR TITLE
Problème de copie du code de récupération après génération

### DIFF
--- a/changelog.d/953.bugfix
+++ b/changelog.d/953.bugfix
@@ -1,0 +1,1 @@
+Problème de copie du code de récupération après génération

--- a/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapSaveRecoveryKeyFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/crypto/recover/BootstrapSaveRecoveryKeyFragment.kt
@@ -18,6 +18,9 @@ package im.vector.app.features.crypto.recover
 
 import android.app.Activity
 import android.content.ActivityNotFoundException
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -93,7 +96,8 @@ class BootstrapSaveRecoveryKeyFragment :
     }
 
     private val copyStartForActivityResult = registerStartForActivityResult { activityResult ->
-        if (activityResult.resultCode == Activity.RESULT_OK) {
+        // Tchap : accept to close sheet even if result is RESULT_CANCELED. The Recovery code is in the clipboard.
+        if (activityResult.resultCode == Activity.RESULT_OK || activityResult.resultCode == Activity.RESULT_CANCELED) {
             // Tchap : Close the dialog without having to tap "Continue"
             sharedViewModel.handle(BootstrapActions.Completed)
         }
@@ -102,6 +106,11 @@ class BootstrapSaveRecoveryKeyFragment :
     private fun shareRecoveryKey() = withState(sharedViewModel) { state ->
         val recoveryKey = state.recoveryKeyCreationInfo?.recoveryKey?.formatRecoveryKey()
                 ?: return@withState
+
+        // Tchap : copy recovery key to clipboard right now after "Copy" button is tapped.
+        val clipboard = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = ClipData.newPlainText("", recoveryKey)
+        clipboard.setPrimaryClip(clip)
 
         startSharePlainTextIntent(
                 requireContext(),


### PR DESCRIPTION
Fix #953 

Accepter de fermer la pop-up de code de récupération même si le retour est "RESULT_CANCELED" car on ne peut pas facilement savoir si l'utilisateur a fait le nécessaire pour sauvegarder son code.

Le code est présent dans le clipboard à ce moment-là.