### PR TITLE
Fix crypto migration for mono session

### DIFF
--- a/changelog.d/979.bugfix
+++ b/changelog.d/979.bugfix
@@ -1,0 +1,1 @@
+Correction des messages chiffrés quand il existe qu'une seule session

--- a/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/RustCryptoService.kt
+++ b/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/RustCryptoService.kt
@@ -498,6 +498,7 @@ internal class RustCryptoService @Inject constructor(
         return try {
             olmMachine.decryptRoomEvent(event)
         } catch (mxCryptoError: MXCryptoError) {
+            // Tchap: try to perform a lazy migration from legacy store if there is no other session.
             if (mxCryptoError is MXCryptoError.Base && mxCryptoError.errorType == MXCryptoError.ErrorType.UNKNOWN_INBOUND_SESSION_ID) {
                 Timber.v("Try to perform a lazy migration from legacy store")
                 /**
@@ -508,7 +509,6 @@ internal class RustCryptoService @Inject constructor(
                 val sessionId = content.sessionId
                 val senderKey = content.senderKey
                 if (roomId != null && sessionId != null) {
-                    // try to perform a lazy migration from legacy store
                     val legacy = tryOrNull("Failed to access legacy crypto store") {
                         cryptoStore.getInboundGroupSession(sessionId, senderKey.orEmpty())
                     }

--- a/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/RustCryptoService.kt
+++ b/matrix-sdk-android/src/rustCrypto/java/org/matrix/android/sdk/internal/crypto/RustCryptoService.kt
@@ -54,6 +54,7 @@ import org.matrix.android.sdk.api.session.crypto.model.MXUsersDevicesMap
 import org.matrix.android.sdk.api.session.events.model.Content
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.api.session.events.model.content.EncryptedEventContent
 import org.matrix.android.sdk.api.session.events.model.content.EncryptionEventContent
 import org.matrix.android.sdk.api.session.events.model.content.RoomKeyContent
 import org.matrix.android.sdk.api.session.events.model.content.RoomKeyWithHeldContent
@@ -133,6 +134,7 @@ internal class RustCryptoService @Inject constructor(
         private val getRoomUserIds: GetRoomUserIdsUseCase,
         private val outgoingRequestsProcessor: OutgoingRequestsProcessor,
         private val matrixConfiguration: MatrixConfiguration,
+        private val rateLimiter: PerSessionBackupQueryRateLimiter,
 ) : CryptoService {
 
     private val isStarting = AtomicBoolean(false)
@@ -493,7 +495,30 @@ internal class RustCryptoService @Inject constructor(
      */
     @Throws(MXCryptoError::class)
     override suspend fun decryptEvent(event: Event, timeline: String): MXEventDecryptionResult {
-        return olmMachine.decryptRoomEvent(event)
+        return try {
+            olmMachine.decryptRoomEvent(event)
+        } catch (mxCryptoError: MXCryptoError) {
+            if (mxCryptoError is MXCryptoError.Base && mxCryptoError.errorType == MXCryptoError.ErrorType.UNKNOWN_INBOUND_SESSION_ID) {
+                Timber.v("Try to perform a lazy migration from legacy store")
+                /**
+                 * It's a bit hacky, check how this can be better integrated with rust?
+                 */
+                val content = event.content?.toModel<EncryptedEventContent>() ?: throw mxCryptoError
+                val roomId = event.roomId
+                val sessionId = content.sessionId
+                val senderKey = content.senderKey
+                if (roomId != null && sessionId != null) {
+                    // try to perform a lazy migration from legacy store
+                    val legacy = tryOrNull("Failed to access legacy crypto store") {
+                        cryptoStore.getInboundGroupSession(sessionId, senderKey.orEmpty())
+                    }
+                    if (legacy == null || olmMachine.importRoomKey(legacy).isFailure) {
+                        rateLimiter.tryFromBackupIfPossible(sessionId, roomId)
+                    }
+                }
+            }
+            throw mxCryptoError
+        }
     }
 
     /**


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [TCHAP_CHANGES.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/TCHAP_CHANGES.md)
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android-v2/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
