### PR TITLE
Update secure flag

### DIFF
--- a/vector/src/main/java/im/vector/app/core/platform/VectorBaseActivity.kt
+++ b/vector/src/main/java/im/vector/app/core/platform/VectorBaseActivity.kt
@@ -233,9 +233,7 @@ abstract class VectorBaseActivity<VB : ViewBinding> : AppCompatActivity(), Maver
         }
 
         // Set flag FLAG_SECURE
-        // Tchap: handle differently screenshot authorization not relying on Preferences flag SETTINGS_SECURITY_USE_FLAG_SECURE
-        // if (vectorPreferences.useFlagSecure()) {
-        if (!vectorPreferences.tchapAllowedScreenshot()) {
+        if (vectorPreferences.useFlagSecure()) {
             window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         }
 

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -993,27 +993,8 @@ class VectorPreferences @Inject constructor(
      * The user does not allow screenshots of the application.
      */
     fun useFlagSecure(): Boolean {
-        return defaultPrefs.getBoolean(SETTINGS_SECURITY_USE_FLAG_SECURE, true)
-    }
-
-    // Tchap
-    /**
-     * Screenshot is not allowed for Tchap F-droid version.
-     * It is allowed for Tchap GPlay version only for DEV and Pre-Prod versions.
-     * It is not allowed for Tchap GPlay Tchap (Production) version.
-     */
-    fun tchapAllowedScreenshot(): Boolean {
-        return when (BuildConfig.FLAVOR_store.lowercase()) {
-            "fdroid" -> false
-            "gplay" -> {
-                when (BuildConfig.FLAVOR_target.lowercase()) {
-                    "devtchap" -> true
-                    "btchap" -> true
-                    else -> false
-                }
-            }
-            else -> false
-        }
+        // Tchap: Screenshot is allowed for Gplay Pre-prod and Dev versions only.
+        return !(BuildConfig.FLAVOR_store == "gplay" && BuildConfig.FLAVOR_target != "tchap")
     }
 
     /** Whether the keyboard should disable personalized learning. */

--- a/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorPreferences.kt
@@ -994,7 +994,7 @@ class VectorPreferences @Inject constructor(
      */
     fun useFlagSecure(): Boolean {
         // Tchap: Screenshot is allowed for Gplay Pre-prod and Dev versions only.
-        return !(BuildConfig.FLAVOR_store == "gplay" && BuildConfig.FLAVOR_target != "tchap")
+        return BuildConfig.FLAVOR_store != "gplay" || BuildConfig.FLAVOR_target == "tchap"
     }
 
     /** Whether the keyboard should disable personalized learning. */


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other :

## Content

<!-- Describe shortly what has been changed -->

Secure flag management improvement

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [TCHAP_CHANGES.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/TCHAP_CHANGES.md)
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android-v2/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
