### PR TITLE
Fix crash in room creation screen

### DIFF
--- a/changelog.d/885.bugfix
+++ b/changelog.d/885.bugfix
@@ -1,0 +1,1 @@
+Correction du crash du nommage du salon lors de sa création.

--- a/vector/src/main/java/fr/gouv/tchap/features/home/roomdirectory/createroom/TchapRoomAvatarWithNameItem.kt
+++ b/vector/src/main/java/fr/gouv/tchap/features/home/roomdirectory/createroom/TchapRoomAvatarWithNameItem.kt
@@ -18,7 +18,6 @@ package fr.gouv.tchap.features.home.roomdirectory.createroom
 import android.net.Uri
 import android.text.Editable
 import android.view.View
-import android.view.inputmethod.EditorInfo
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.view.isVisible
@@ -81,9 +80,6 @@ abstract class TchapRoomAvatarWithNameItem : EpoxyModelWithHolder<TchapRoomAvata
     var singleLine: Boolean = true
 
     @EpoxyAttribute
-    var imeOptions: Int? = null
-
-    @EpoxyAttribute
     var endIconMode: Int? = null
 
     // FIXME restore EpoxyAttribute.Option.DoNotHash and fix that properly
@@ -141,7 +137,6 @@ abstract class TchapRoomAvatarWithNameItem : EpoxyModelWithHolder<TchapRoomAvata
         holder.textInputEditText.isEnabled = enabled
         inputType?.let { holder.textInputEditText.inputType = it }
         holder.textInputEditText.isSingleLine = singleLine
-        holder.textInputEditText.imeOptions = imeOptions ?: EditorInfo.IME_ACTION_NONE
 
         holder.textInputEditText.addTextChangedListener(onTextChangeListener)
         holder.textInputEditText.setOnEditorActionListener(editorActionListener)


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

The App crash in room creation screen after editing the room name.
related to #885 

## Motivation and context

- Go to room creation screen
- Focus on room name text input field
- Enter a room name
- Tap on done key

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [ ] Pull request updates [TCHAP_CHANGES.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/TCHAP_CHANGES.md)
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android-v2/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
