### PR TITLE
Remove the option "Convertir en salon privé (irréversible)"

### DIFF
--- a/changelog.d/1007.improvements
+++ b/changelog.d/1007.improvements
@@ -1,0 +1,1 @@
+Remove the option "Convertir en salon privé (irréversible)"

--- a/library/ui-strings/src/main/res/values-fr/strings_tchap.xml
+++ b/library/ui-strings/src/main/res/values-fr/strings_tchap.xml
@@ -53,8 +53,6 @@
     <string name="tchap_scan_media_warning_apk">Pour des raisons de sécurité l’installation d’application à partir de ${app_name} n’est pas autorisée.</string>
 
     <!-- tchap room settings -->
-    <string name="tchap_room_settings_convert_to_private">Convertir en salon privé (irréversible)</string>
-    <string name="tchap_room_settings_convert_to_private_prompt_msg"><b>Cette action est irréversible.</b>\nVoulez-vous vraiment convertir ce forum en salon privé ?</string>
     <string name="tchap_room_settings_room_access_title">Gestion des comptes externes</string>
     <string name="tchap_room_settings_room_access_restricted">Les externes ne sont pas autorisés à rejoindre ce salon</string>
     <string name="tchap_room_settings_room_access_unrestricted">Les externes sont autorisés à rejoindre ce salon</string>

--- a/library/ui-strings/src/main/res/values/strings_tchap.xml
+++ b/library/ui-strings/src/main/res/values/strings_tchap.xml
@@ -53,8 +53,6 @@
     <string name="tchap_scan_media_warning_apk">For security reasons, installing applications from ${app_name} is not allowed.</string>
 
     <!-- tchap room settings -->
-    <string name="tchap_room_settings_convert_to_private">Convert to private room (irreversible)</string>
-    <string name="tchap_room_settings_convert_to_private_prompt_msg"><b>This action is irreversible.</b>\nAre you sure you want to convert this forum into a private room?</string>
     <string name="tchap_room_settings_room_access_title">External accounts handling</string>
     <string name="tchap_room_settings_room_access_restricted">The externals are not allowed to join this room</string>
     <string name="tchap_room_settings_room_access_unrestricted">The externals are allowed to join this room</string>

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsAction.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsAction.kt
@@ -28,7 +28,6 @@ sealed class RoomSettingsAction : VectorViewModelAction {
     data class SetRoomHistoryVisibility(val visibility: RoomHistoryVisibility) : RoomSettingsAction()
     data class SetRoomJoinRule(val roomJoinRule: RoomJoinRules) : RoomSettingsAction()
     data class SetRoomGuestAccess(val guestAccess: GuestAccess) : RoomSettingsAction()
-    object RemoveFromRoomsDirectory : RoomSettingsAction()
     object AllowExternalUsersToJoin : RoomSettingsAction()
 
     object Save : RoomSettingsAction()

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsController.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsController.kt
@@ -23,7 +23,6 @@ import im.vector.app.R
 import im.vector.app.core.epoxy.dividerItem
 import im.vector.app.core.epoxy.profiles.buildProfileAction
 import im.vector.app.core.epoxy.profiles.buildProfileSection
-import im.vector.app.core.error.ErrorFormatter
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.core.ui.list.verticalMarginItem
 import im.vector.app.core.utils.DimensionConverter
@@ -32,7 +31,6 @@ import im.vector.app.features.form.formEditableAvatarItem
 import im.vector.app.features.home.AvatarRenderer
 import im.vector.app.features.home.room.detail.timeline.format.RoomHistoryVisibilityFormatter
 import im.vector.app.features.settings.VectorPreferences
-import org.matrix.android.sdk.api.session.room.model.RoomDirectoryVisibility
 import org.matrix.android.sdk.api.util.toMatrixItem
 import javax.inject.Inject
 
@@ -41,7 +39,6 @@ class RoomSettingsController @Inject constructor(
         private val avatarRenderer: AvatarRenderer,
         private val dimensionConverter: DimensionConverter,
         private val roomHistoryVisibilityFormatter: RoomHistoryVisibilityFormatter,
-        private val errorFormatter: ErrorFormatter,
         private val vectorPreferences: VectorPreferences
 ) : TypedEpoxyController<RoomSettingsViewState>() {
 
@@ -54,7 +51,6 @@ class RoomSettingsController @Inject constructor(
         fun onHistoryVisibilityClicked()
         fun onJoinRuleClicked()
         fun onToggleGuestAccess()
-        fun onRemoveFromRoomsDirectory()
         fun onAccessByLinkClicked()
         fun onAllowExternalUsersToJoin()
     }
@@ -153,12 +149,6 @@ class RoomSettingsController @Inject constructor(
 
         buildRoomAccessRules(data, roomType)
 
-        if (data.actionPermissions.canRemoveFromRoomsDirectory &&
-                (roomType == TchapRoomType.FORUM ||
-                        (roomType == TchapRoomType.UNKNOWN && data.roomDirectoryVisibility() == RoomDirectoryVisibility.PUBLIC))) {
-            buildRemoveFromRoomsDirectory()
-        }
-
         // Tchap: Disable "Allow guest to join" switch
 //        val isPublic = (data.newRoomJoinRules.newJoinRules ?: data.currentRoomJoinRules) == RoomJoinRules.PUBLIC
 //        if (vectorPreferences.developerMode() && isPublic) {
@@ -176,18 +166,6 @@ class RoomSettingsController @Inject constructor(
 //                id("guestAccessDivider")
 //            }
 //        }
-    }
-
-    private fun buildRemoveFromRoomsDirectory() {
-        val host = this
-        buildProfileAction(
-                id = "removeFromRoomsDirectory",
-                title = stringProvider.getString(R.string.tchap_room_settings_convert_to_private),
-                divider = true,
-                destructive = true,
-                editable = false,
-                action = { host.callback?.onRemoveFromRoomsDirectory() }
-        )
     }
 
     private fun buildRoomAccessRules(data: RoomSettingsViewState, roomType: TchapRoomType) {

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsFragment.kt
@@ -206,17 +206,6 @@ class RoomSettingsFragment :
         viewModel.handle(RoomSettingsAction.SetRoomGuestAccess(toggled))
     }
 
-    override fun onRemoveFromRoomsDirectory() {
-        MaterialAlertDialogBuilder(requireContext(), R.style.ThemeOverlay_Vector_MaterialAlertDialog_Destructive)
-                .setTitle(R.string.dialog_title_warning)
-                .setMessage(getString(R.string.tchap_room_settings_convert_to_private_prompt_msg))
-                .setPositiveButton(R.string.yes) { _, _ ->
-                    viewModel.handle(RoomSettingsAction.RemoveFromRoomsDirectory)
-                }
-                .setNegativeButton(R.string.action_cancel, null)
-                .show()
-    }
-
     override fun onImageReady(uri: Uri?) {
         uri ?: return
         viewModel.handle(

--- a/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsViewState.kt
+++ b/vector/src/main/java/im/vector/app/features/roomprofile/settings/RoomSettingsViewState.kt
@@ -24,7 +24,6 @@ import im.vector.app.R
 import im.vector.app.core.resources.StringProvider
 import im.vector.app.features.roomprofile.RoomProfileArgs
 import org.matrix.android.sdk.api.session.room.model.GuestAccess
-import org.matrix.android.sdk.api.session.room.model.RoomDirectoryVisibility
 import org.matrix.android.sdk.api.session.room.model.RoomHistoryVisibility
 import org.matrix.android.sdk.api.session.room.model.RoomJoinRules
 import org.matrix.android.sdk.api.session.room.model.RoomSummary
@@ -47,7 +46,6 @@ data class RoomSettingsViewState(
         val actionPermissions: ActionPermissions = ActionPermissions(),
         val supportsRestricted: Boolean = false,
         val canUpgradeToRestricted: Boolean = false,
-        val roomDirectoryVisibility: Async<RoomDirectoryVisibility> = Uninitialized
 ) : MavericksState {
 
     constructor(args: RoomProfileArgs) : this(roomId = args.roomId)
@@ -60,7 +58,6 @@ data class RoomSettingsViewState(
             val canChangeJoinRule: Boolean = false,
             val canChangeCanonicalAlias: Boolean = false,
             val canAddChildren: Boolean = false,
-            val canRemoveFromRoomsDirectory: Boolean = false,
             val canChangeRoomAccessRules: Boolean = false
     ) {
         val canChangeAccessByLink: Boolean


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->

#1007 
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [x] Pull request updates [TCHAP_CHANGES.md](https://github.com/tchapgouv/tchap-android-v2/blob/develop/TCHAP_CHANGES.md)
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android-v2/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android-v2/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
