### PR TITLE
Add security exception for openmaptiles.github.io

### DIFF
--- a/changelog.d/1049.bugfix
+++ b/changelog.d/1049.bugfix
@@ -1,0 +1,1 @@
+Ajout d'une exception de sécurité pour le domaine openmaptiles.github.io

--- a/vector-config/src/tchap/res/values/config-features.xml
+++ b/vector-config/src/tchap/res/values/config-features.xml
@@ -4,5 +4,7 @@
     <bool name="tchap_is_key_backup_enabled">true</bool>
     <bool name="tchap_is_thread_enabled">false</bool>
 
-    <string-array name="tchap_is_voip_supported_homeservers" translatable="false" />
+    <string-array name="tchap_is_voip_supported_homeservers" translatable="false">
+        <item>agent.dinum.tchap.gouv.fr</item>
+    </string-array>
 </resources>

--- a/vector/src/withpinning/res/xml/network_security_config.xml
+++ b/vector/src/withpinning/res/xml/network_security_config.xml
@@ -13,6 +13,7 @@
     <!-- Allow system certificates for firebase if used. No effect on FDroid variant -->
     <domain-config cleartextTrafficPermitted="false">
         <domain includeSubdomains="false">firebaseinstallations.googleapis.com</domain>
+        <domain includeSubdomains="false">openmaptiles.github.io</domain>
         <trust-anchors>
             <certificates src="system" />
         </trust-anchors>


### PR DESCRIPTION
Limit VoIP for DINUM agents

<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
