### PR TITLE
Opening FAQ in app

### DIFF
--- a/changelog.d/906.bugfix
+++ b/changelog.d/906.bugfix
@@ -1,0 +1,1 @@
+Ouverture de l'aide dans l'application au lieu du navigateur.

--- a/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
+++ b/vector/src/main/java/im/vector/app/features/home/HomeActivity.kt
@@ -689,9 +689,12 @@ class HomeActivity :
                 launchQrCode()
                 true
             }
-            // TCHAP new faq entry
+            // TCHAP new faq entry.
+            // the FAQ url is detected as a permalink (same prefix), which make the application fail to open it from
+            // ChromeCustomTab, so we open it here directly in a WebView
             R.id.menu_home_faq -> {
-                openUrlInChromeCustomTab(this, null, VectorSettingsUrls.HELP)
+                val intent = VectorWebViewActivity.getIntent(this, VectorSettingsUrls.HELP, getString(R.string.preference_help))
+                startActivity(intent)
                 true
             }
             else -> false

--- a/vector/src/main/java/im/vector/app/features/settings/VectorSettingsRootFragment.kt
+++ b/vector/src/main/java/im/vector/app/features/settings/VectorSettingsRootFragment.kt
@@ -27,6 +27,7 @@ import im.vector.app.core.utils.openUrlInChromeCustomTab
 import im.vector.app.features.VectorFeatures
 import im.vector.app.features.analytics.plan.MobileScreen
 import im.vector.app.features.displayname.getBestName
+import im.vector.app.features.webview.VectorWebViewActivity
 import org.matrix.android.sdk.api.session.getUserOrDefault
 import org.matrix.android.sdk.api.util.toMatrixItem
 import javax.inject.Inject
@@ -54,7 +55,8 @@ class VectorSettingsRootFragment :
         findPreference<VectorPreference>(VectorPreferences.SETTINGS_HELP_PREFERENCE_KEY)!!
                 .onPreferenceClickListener = Preference.OnPreferenceClickListener {
             if (firstThrottler.canHandle() is FirstThrottler.CanHandlerResult.Yes) {
-                openUrlInChromeCustomTab(requireContext(), null, VectorSettingsUrls.HELP)
+                val intent = VectorWebViewActivity.getIntent(requireContext(), VectorSettingsUrls.HELP, getString(R.string.preference_help))
+                startActivity(intent)
             }
             false
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

Blocked by https://github.com/tchapgouv/tchap-android/issues/906#issuecomment-2144787186

## Motivation and context

#906 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
