### PR TITLE
Display reply to only if the root event is a text message.

### DIFF
--- a/changelog.d/1080.bugfix
+++ b/changelog.d/1080.bugfix
@@ -1,0 +1,1 @@
+Correction de l'affichage des fichiers dans une réponse ou un thread.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/decorator/UpdatedReplyDecorator.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/room/timeline/decorator/UpdatedReplyDecorator.kt
@@ -19,6 +19,7 @@ package org.matrix.android.sdk.internal.session.room.timeline.decorator
 import io.realm.Realm
 import org.matrix.android.sdk.api.session.events.model.Event
 import org.matrix.android.sdk.api.session.events.model.EventType
+import org.matrix.android.sdk.api.session.events.model.isTextMessage
 import org.matrix.android.sdk.api.session.events.model.isThread
 import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.room.timeline.TimelineEvent
@@ -40,7 +41,8 @@ internal class UpdatedReplyDecorator(
 ) : TimelineEventDecorator {
 
     override fun decorate(timelineEvent: TimelineEvent): TimelineEvent {
-        return if (timelineEvent.isReply() && !timelineEvent.root.isThread()) {
+        // TCHAP Display reply to only if the root event is a text message.
+        return if (timelineEvent.isReply() && !timelineEvent.root.isThread() && timelineEvent.root.isTextMessage()) {
             val newRepliedEvent = createNewRepliedEvent(timelineEvent) ?: return timelineEvent
             timelineEvent.copy(root = newRepliedEvent)
         } else {

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/ThreadsAwarenessHandler.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/sync/handler/room/ThreadsAwarenessHandler.kt
@@ -27,6 +27,7 @@ import org.matrix.android.sdk.api.session.events.model.RelationType
 import org.matrix.android.sdk.api.session.events.model.getRelationContentForType
 import org.matrix.android.sdk.api.session.events.model.getRootThreadEventId
 import org.matrix.android.sdk.api.session.events.model.isSticker
+import org.matrix.android.sdk.api.session.events.model.isTextMessage
 import org.matrix.android.sdk.api.session.events.model.toContent
 import org.matrix.android.sdk.api.session.events.model.toModel
 import org.matrix.android.sdk.api.session.room.model.message.MessageFormat
@@ -168,7 +169,8 @@ internal class ThreadsAwarenessHandler @Inject constructor(
         roomId ?: return null
         if (lightweightSettingsStorage.areThreadMessagesEnabled() && !isReplyEvent(event)) return null
         handleRootThreadEventsIfNeeded(realm, roomId, eventEntity, event)
-        if (!isThreadEvent(event)) return null
+        // TCHAP Display reply to only if the root event is a text message.
+        if (!isThreadEvent(event) || !event.isTextMessage()) return null
         val eventPayload = if (!event.isEncrypted()) {
             event.content?.toMutableMap() ?: return null
         } else {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
