### PR TITLE
Improve content report

### DIFF
--- a/changelog.d/1083.improvements
+++ b/changelog.d/1083.improvements
@@ -1,0 +1,1 @@
+Amélioration du parcours de signalement de contenu.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-    version = "2.13.1"
+    version = "2.13.2"
     directory = "changelog.d"
     filename = "TCHAP_CHANGES.md"
     name = "Changes in Tchap"

--- a/vector-app/build.gradle
+++ b/vector-app/build.gradle
@@ -37,7 +37,7 @@ ext.versionMinor = 13
 // Note: even values are reserved for regular release, odd values for hotfix release.
 // When creating a hotfix, you should decrease the value, since the current value
 // is the value for the next regular release.
-ext.versionPatch = 1
+ext.versionPatch = 2
 
 static def getGitTimestamp() {
     def cmd = 'git show -s --format=%ct'

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/EventSharedAction.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/EventSharedAction.kt
@@ -95,7 +95,7 @@ sealed class EventSharedAction(
             EventSharedAction(CommonStrings.report_content_inappropriate, R.drawable.ic_report_inappropriate)
 
     data class ReportContentCustom(val eventId: String, val senderId: String?) :
-            EventSharedAction(CommonStrings.report_content_custom, R.drawable.ic_report_custom)
+            EventSharedAction(CommonStrings.report_content, R.drawable.ic_flag) // TCHAP Use custom report content by default.
 
     data class IgnoreUser(val senderId: String?) :
             EventSharedAction(CommonStrings.message_ignore_user, R.drawable.ic_alert_triangle, true)

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/timeline/action/MessageActionsViewModel.kt
@@ -424,17 +424,19 @@ class MessageActionsViewModel @AssistedInject constructor(
         if (session.myUserId != timelineEvent.root.senderId) {
             // not sent by me
             if (timelineEvent.root.isContentReportable()) {
-                add(EventSharedAction.ReportContent(eventId, timelineEvent.root.senderId))
+                // TCHAP Use custom report content by default.
+                add(EventSharedAction.ReportContentCustom(eventId, timelineEvent.root.senderId))
             }
 
             add(EventSharedAction.Separator)
             add(EventSharedAction.IgnoreUser(timelineEvent.root.senderId))
-            add(
-                    EventSharedAction.ReportUser(
-                            eventId = eventId,
-                            senderId = timelineEvent.root.senderId,
-                    )
-            )
+            // TCHAP Hide user report feature in event action list.
+//            add(
+//                    EventSharedAction.ReportUser(
+//                            eventId = eventId,
+//                            senderId = timelineEvent.root.senderId,
+//                    )
+//            )
         }
     }
 

--- a/vector/src/main/res/drawable/ic_report_custom.xml
+++ b/vector/src/main/res/drawable/ic_report_custom.xml
@@ -1,8 +1,0 @@
-<vector android:autoMirrored="true" android:height="22dp"
-    android:viewportHeight="22" android:viewportWidth="22"
-    android:width="22dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#00000000" android:fillType="evenOdd"
-        android:pathData="M21,1L10,12M21,1l-7,20 -4,-9 -9,-4z"
-        android:strokeColor="#9E9E9E" android:strokeLineCap="round"
-        android:strokeLineJoin="round" android:strokeWidth="2"/>
-</vector>


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->
#1083 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

|Before|After|
|-|-|
|<img width="503" alt="image" src="https://github.com/user-attachments/assets/96fc4b6a-c555-48ea-9613-6d140ad7d8cc">|<img width="503" alt="image" src="https://github.com/user-attachments/assets/1eb0577c-7466-4140-a1de-63992690f54c">|

<img width="503" alt="image" src="https://github.com/user-attachments/assets/bfddca9d-ff38-415e-934f-ed5d76ddecf6">

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
