### PR TITLE
Update R8 (proguard) configuration to support guava

### DIFF
--- a/vector-app/proguard-rules.pro
+++ b/vector-app/proguard-rules.pro
@@ -85,6 +85,7 @@
 -dontwarn com.google.appengine.api.urlfetch.**
 -dontwarn com.google.common.io.LimitInputStream
 -dontwarn com.google.firebase.analytics.connector.AnalyticsConnector
+-dontwarn com.google.j2objc.annotations.** # TCHAP guava rule
 -dontwarn com.google.javascript.jscomp.**
 -dontwarn com.likethesalad.android.templates.provider.api.TemplatesProvider
 -dontwarn com.yahoo.platform.yui.compressor.**

--- a/vector/build.gradle
+++ b/vector/build.gradle
@@ -278,14 +278,16 @@ dependencies {
     implementation "androidx.emoji2:emoji2:1.3.0"
 
     // TCHAP Manage jitsi lib
+    // Guava
+    implementation('com.google.guava:guava:33.2.1-android')
     // WebRTC
     withdmvoipImplementation('com.github.tchapgouv:webrtc:124.2.0')
-    withdmvoipImplementation('com.google.guava:guava:33.2.1-android')
     // Jitsi
     withvoipApi('org.jitsi.react:jitsi-meet-sdk:8.1.1') {
         exclude group: 'com.google.firebase'
         exclude group: 'com.google.android.gms'
         exclude group: 'com.android.installreferrer'
+        exclude group: 'com.android.guava'
 
         // Exclude jitsi's android-scalablevideoview fork's support library
         // The library exports a jetified artifact but doesn't remove the support library dependency


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Release can't build

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
