### PR TITLE
Add explicit error when a user is not allowed to access a room.

### DIFF
--- a/changelog.d/1118.improvements
+++ b/changelog.d/1118.improvements
@@ -1,0 +1,1 @@
+Améliorer l'explication pour un externe voulant rejoindre un salon sans autorisation.

--- a/vector/src/main/java/im/vector/app/core/error/ErrorFormatter.kt
+++ b/vector/src/main/java/im/vector/app/core/error/ErrorFormatter.kt
@@ -123,7 +123,8 @@ class DefaultErrorFormatter @Inject constructor(
                     throwable.error.code == MatrixError.M_PASSWORD_NO_SYMBOL -> {
                         stringProvider.getString(CommonStrings.tchap_register_pwd_no_symbol)
                     }
-                    throwable.error.code == MatrixError.M_UNKNOWN &&
+                    // TCHAP Add explicit error when a user is not allowed to access a room.
+                    (throwable.error.code == MatrixError.M_UNKNOWN || throwable.error.code == MatrixError.M_FORBIDDEN) &&
                             throwable.error.message == "Not allowed to join this room" -> {
                         stringProvider.getString(CommonStrings.room_error_access_unauthorized)
                     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [ ] Bugfix
- [ ] Technical
- [x] Other :

## Content

#1118 

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

![image](https://github.com/user-attachments/assets/594ba90e-1093-43ba-9311-8ae47b9b3558)


<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#changelog
- [x] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
