### PR TITLE
Fix crash for incoming call

### DIFF
--- a/changelog.d/1126.bugfix
+++ b/changelog.d/1126.bugfix
@@ -1,0 +1,1 @@
+Correction du crash sur Android 14 quand on reçoit un appel sur Tchap.

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,5 +1,5 @@
 [tool.towncrier]
-    version = "2.13.8"
+    version = "2.13.9"
     directory = "changelog.d"
     filename = "TCHAP_CHANGES.md"
     name = "Changes in Tchap"

--- a/vector-app/build.gradle
+++ b/vector-app/build.gradle
@@ -37,7 +37,7 @@ ext.versionMinor = 13
 // Note: even values are reserved for regular release, odd values for hotfix release.
 // When creating a hotfix, you should decrease the value, since the current value
 // is the value for the next regular release.
-ext.versionPatch = 8
+ext.versionPatch = 9
 
 static def getGitTimestamp() {
     def cmd = 'git show -s --format=%ct'

--- a/vector-config/src/tchap/res/values/config-features.xml
+++ b/vector-config/src/tchap/res/values/config-features.xml
@@ -9,6 +9,5 @@
         <item>agent.dinum.tchap.gouv.fr</item>
         <item>agent.education.tchap.gouv.fr</item>
         <item>agent.tchap.gouv.fr</item>
-        <item>agent.intradef.tchap.gouv.fr</item>
     </string-array>
 </resources>

--- a/vector/src/main/java/im/vector/app/core/services/CallAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/core/services/CallAndroidService.kt
@@ -181,11 +181,8 @@ class CallAndroidService : VectorAndroidService() {
                 title = callInformation.opponentMatrixItem?.getBestName() ?: callInformation.opponentUserId,
                 fromBg = fromBg
         )
-        if (knownCalls.isEmpty()) {
-            startForegroundCompat(callId.hashCode(), notification)
-        } else {
-            notificationManager.notify(callId.hashCode(), notification)
-        }
+        //TCHAP fix crash when a call incoming on Androd 14 and higher
+        notificationManager.notify(callId.hashCode(), notification)
         knownCalls[callId] = callInformation
     }
 
@@ -202,7 +199,8 @@ class CallAndroidService : VectorAndroidService() {
         }
         val notification = notificationUtils.buildCallEndedNotification(false)
         val notificationId = callId.hashCode()
-        startForegroundCompat(notificationId, notification)
+        //TCHAP fix crash when a call incoming on Androd 14 and higher
+        notificationManager.notify(notificationId, notification)
         if (knownCalls.isEmpty()) {
             Timber.tag(loggerTag.value).v("No more call, stop the service")
             stopForegroundCompat()
@@ -260,11 +258,8 @@ class CallAndroidService : VectorAndroidService() {
                 call = call,
                 title = callInformation.opponentMatrixItem?.getBestName() ?: callInformation.opponentUserId
         )
-        if (knownCalls.isEmpty()) {
-            startForegroundCompat(callId.hashCode(), notification)
-        } else {
-            notificationManager.notify(callId.hashCode(), notification)
-        }
+        //TCHAP fix crash when a call incoming on Androd 14 and higher
+        startForegroundCompat(callId.hashCode(), notification)
         knownCalls[callId] = callInformation
     }
 

--- a/vector/src/main/java/im/vector/app/core/services/CallAndroidService.kt
+++ b/vector/src/main/java/im/vector/app/core/services/CallAndroidService.kt
@@ -181,7 +181,7 @@ class CallAndroidService : VectorAndroidService() {
                 title = callInformation.opponentMatrixItem?.getBestName() ?: callInformation.opponentUserId,
                 fromBg = fromBg
         )
-        //TCHAP fix crash when a call incoming on Androd 14 and higher
+        // TCHAP fix crash when a call incoming on Androd 14 and higher
         notificationManager.notify(callId.hashCode(), notification)
         knownCalls[callId] = callInformation
     }
@@ -199,7 +199,7 @@ class CallAndroidService : VectorAndroidService() {
         }
         val notification = notificationUtils.buildCallEndedNotification(false)
         val notificationId = callId.hashCode()
-        //TCHAP fix crash when a call incoming on Androd 14 and higher
+        // TCHAP fix crash when a call incoming on Androd 14 and higher
         notificationManager.notify(notificationId, notification)
         if (knownCalls.isEmpty()) {
             Timber.tag(loggerTag.value).v("No more call, stop the service")
@@ -258,7 +258,7 @@ class CallAndroidService : VectorAndroidService() {
                 call = call,
                 title = callInformation.opponentMatrixItem?.getBestName() ?: callInformation.opponentUserId
         )
-        //TCHAP fix crash when a call incoming on Androd 14 and higher
+        // TCHAP fix crash when a call incoming on Androd 14 and higher
         startForegroundCompat(callId.hashCode(), notification)
         knownCalls[callId] = callInformation
     }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [ ] Feature
- [x] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

#1126 
<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [x] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
