### PR TITLE
Support authenticated media with content scanner

### DIFF
--- a/changelog.d/1152.sdk
+++ b/changelog.d/1152.sdk
@@ -1,0 +1,1 @@
+Support des API de medias authentifiés avec l'anti-virus.

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultFileService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultFileService.kt
@@ -150,7 +150,7 @@ internal class DefaultFileService @Inject constructor(
                                     .url(resolvedMethod.url)
                                     .header(DOWNLOAD_PROGRESS_INTERCEPTOR_HEADER, url)
 
-                            if (isAuthenticatedMediaSupported()) {
+                            if (contentUrlResolver.requiresAuthentication(resolvedMethod.url)) {
                                 val accessToken = accessTokenProvider.getToken()
                                 requestBuilder.addAuthenticationHeader(accessToken)
                             }

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultFileService.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/DefaultFileService.kt
@@ -39,6 +39,7 @@ import org.matrix.android.sdk.internal.di.UnauthenticatedWithCertificateWithProg
 import org.matrix.android.sdk.internal.network.httpclient.addAuthenticationHeader
 import org.matrix.android.sdk.internal.network.token.AccessTokenProvider
 import org.matrix.android.sdk.internal.session.download.DownloadProgressInterceptor.Companion.DOWNLOAD_PROGRESS_INTERCEPTOR_HEADER
+import org.matrix.android.sdk.internal.session.media.IsAuthenticatedMediaSupported
 import org.matrix.android.sdk.internal.util.file.AtomicFileCreator
 import org.matrix.android.sdk.internal.util.file.safeFileName
 import org.matrix.android.sdk.internal.util.time.Clock
@@ -55,6 +56,7 @@ internal class DefaultFileService @Inject constructor(
         private val contentUrlResolver: ContentUrlResolver,
         @UnauthenticatedWithCertificateWithProgress
         private val okHttpClient: OkHttpClient,
+        private val isAuthenticatedMediaSupported: IsAuthenticatedMediaSupported,
         private val coroutineDispatchers: MatrixCoroutineDispatchers,
         private val clock: Clock,
         @Authenticated private val accessTokenProvider: AccessTokenProvider,
@@ -144,11 +146,15 @@ internal class DefaultFileService @Inject constructor(
                         }
 
                         is ContentUrlResolver.ResolvedMethod.POST -> {
-                            Request.Builder()
+                            val requestBuilder = Request.Builder()
                                     .url(resolvedMethod.url)
                                     .header(DOWNLOAD_PROGRESS_INTERCEPTOR_HEADER, url)
-                                    .post(resolvedMethod.jsonBody.toRequestBody("application/json".toMediaType()))
-                                    .build()
+
+                            if (isAuthenticatedMediaSupported()) {
+                                val accessToken = accessTokenProvider.getToken()
+                                requestBuilder.addAuthenticationHeader(accessToken)
+                            }
+                            requestBuilder.post(resolvedMethod.jsonBody.toRequestBody("application/json".toMediaType())).build()
                         }
                     }
 

--- a/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/DefaultContentUrlResolver.kt
+++ b/matrix-sdk-android/src/main/java/org/matrix/android/sdk/internal/session/content/DefaultContentUrlResolver.kt
@@ -37,6 +37,7 @@ internal class DefaultContentUrlResolver @Inject constructor(
 
     private val baseUrl = homeServerConnectionConfig.homeServerUriBase.toString().ensureTrailingSlash()
     private val authenticatedMediaApiPath = baseUrl + NetworkConstants.URI_API_PREFIX_PATH_V1 + "media/"
+    private val mediaProxyApiPath = baseUrl + NetworkConstants.URI_API_PREFIX_PATH_MEDIA_PROXY_UNSTABLE
     override val uploadUrl = baseUrl + NetworkConstants.URI_API_MEDIA_PREFIX_PATH_R0 + "upload"
 
     override fun resolveForDownload(contentUrl: String?, elementToDecrypt: ElementToDecrypt?): ContentUrlResolver.ResolvedMethod? {
@@ -83,7 +84,7 @@ internal class DefaultContentUrlResolver @Inject constructor(
     }
 
     override fun requiresAuthentication(resolvedUrl: String): Boolean {
-        return resolvedUrl.startsWith(authenticatedMediaApiPath)
+        return resolvedUrl.startsWith(mediaProxyApiPath) && isAuthenticatedMediaSupported() || resolvedUrl.startsWith(authenticatedMediaApiPath)
     }
 
     private fun resolve(

--- a/vector/src/main/java/im/vector/app/features/home/AvatarRenderer.kt
+++ b/vector/src/main/java/im/vector/app/features/home/AvatarRenderer.kt
@@ -284,16 +284,6 @@ class AvatarRenderer @Inject constructor(
                 }
     }
 
-    @AnyThread
-    fun getSpacePlaceholderDrawable(matrixItem: MatrixItem): Drawable {
-        val avatarColor = matrixItemColorProvider.getColor(matrixItem)
-        return TextDrawable.builder()
-                .beginConfig()
-                .bold()
-                .endConfig()
-                .buildRoundRect(matrixItem.firstLetterOfDisplayName(), avatarColor, dimensionConverter.dpToPx(8))
-    }
-
     // PRIVATE API *********************************************************************************
 
     private fun GlideRequests.loadResolvedUrl(avatarUrl: String?): GlideRequest<Drawable> {


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->

## Motivation and context

#1153 

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
