### PR TITLE
Add visio command

### DIFF
--- a/changelog.d/1162.feature
+++ b/changelog.d/1162.feature
@@ -1,0 +1,1 @@
+Ajout de la commande /visio pour créer une réunion sur https://visio.numerique.gouv.fr

--- a/library/ui-strings/src/main/res/values-fr/strings_tchap.xml
+++ b/library/ui-strings/src/main/res/values-fr/strings_tchap.xml
@@ -37,7 +37,7 @@
     <string name="tchap_empty_room_no_permission_to_post">Votre destinataire a quitté le salon ou refusé votre invitation. Vous ne pouvez pas lui envoyer de message.</string>
     <string name="tchap_discovery_section">Utilisateur trouvé</string>
     <string name="tchap_login_reset_password_on">Réinitialiser le mot de passe</string>
-    <string name="tchap_command_description_lasuite_visio">Crée une réunion avec le message suivant</string>
+    <string name="tchap_command_description_lasuite_visio">Crée un lien Visio avec le message suivant</string>
 
     <!-- tchap discussion -->
     <string name="tchap_contact_external">Externe</string>

--- a/library/ui-strings/src/main/res/values-fr/strings_tchap.xml
+++ b/library/ui-strings/src/main/res/values-fr/strings_tchap.xml
@@ -37,6 +37,7 @@
     <string name="tchap_empty_room_no_permission_to_post">Votre destinataire a quitté le salon ou refusé votre invitation. Vous ne pouvez pas lui envoyer de message.</string>
     <string name="tchap_discovery_section">Utilisateur trouvé</string>
     <string name="tchap_login_reset_password_on">Réinitialiser le mot de passe</string>
+    <string name="tchap_command_description_lasuite_visio">Crée une réunion avec le message suivant</string>
 
     <!-- tchap discussion -->
     <string name="tchap_contact_external">Externe</string>

--- a/library/ui-strings/src/main/res/values/strings_tchap.xml
+++ b/library/ui-strings/src/main/res/values/strings_tchap.xml
@@ -37,6 +37,7 @@
     <string name="tchap_empty_room_no_permission_to_post">Your recipient has left the room or has refused your invite. You cannot send him a message.</string>
     <string name="tchap_discovery_section">Discovered user</string>
     <string name="tchap_login_reset_password_on">Reset password</string>
+    <string name="tchap_command_description_lasuite_visio">Create a meeting with a message</string>
 
     <!-- tchap discussion -->
     <string name="tchap_contact_external">External</string>

--- a/library/ui-strings/src/main/res/values/strings_tchap.xml
+++ b/library/ui-strings/src/main/res/values/strings_tchap.xml
@@ -37,7 +37,7 @@
     <string name="tchap_empty_room_no_permission_to_post">Your recipient has left the room or has refused your invite. You cannot send him a message.</string>
     <string name="tchap_discovery_section">Discovered user</string>
     <string name="tchap_login_reset_password_on">Reset password</string>
-    <string name="tchap_command_description_lasuite_visio">Create a meeting with a message</string>
+    <string name="tchap_command_description_lasuite_visio">Create a link to Visio with a message</string>
 
     <!-- tchap discussion -->
     <string name="tchap_contact_external">External</string>

--- a/vector/src/main/java/im/vector/app/features/command/Command.kt
+++ b/vector/src/main/java/im/vector/app/features/command/Command.kt
@@ -23,6 +23,7 @@ enum class Command(
         val isDevCommand: Boolean,
         val isThreadCommand: Boolean
 ) {
+    LASUITE_VISIO("/visio", null, "<message>", CommonStrings.tchap_command_description_lasuite_visio, false, true),
     CRASH_APP("/crash", null, "", CommonStrings.command_description_crash_application, true, true),
     EMOTE("/me", null, "<message>", CommonStrings.command_description_emote, false, true),
     BAN_USER("/ban", null, "<user-id> [reason]", CommonStrings.command_description_ban_user, false, false),
@@ -69,6 +70,7 @@ enum class Command(
      */
     val isTchapCommand
         get() = when (this) {
+            LASUITE_VISIO,
             DISCARD_SESSION,
             EMOTE,
             MARKDOWN,

--- a/vector/src/main/java/im/vector/app/features/command/CommandParser.kt
+++ b/vector/src/main/java/im/vector/app/features/command/CommandParser.kt
@@ -61,6 +61,9 @@ class CommandParser @Inject constructor(
             }
 
             when {
+                Command.LASUITE_VISIO.matches(slashCommand) -> {
+                    ParsedCommand.SendVisioUrl(message)
+                }
                 Command.PLAIN.matches(slashCommand) -> {
                     if (message.isNotEmpty()) {
                         if (formattedMessage != null) {

--- a/vector/src/main/java/im/vector/app/features/command/ParsedCommand.kt
+++ b/vector/src/main/java/im/vector/app/features/command/ParsedCommand.kt
@@ -32,6 +32,7 @@ sealed interface ParsedCommand {
 
     // Valid commands:
 
+    data class SendVisioUrl(val message: CharSequence) : ParsedCommand
     data class SendPlainText(val message: CharSequence) : ParsedCommand
     data class SendFormattedText(val message: CharSequence, val formattedMessage: String) : ParsedCommand
     data class SendEmote(val message: CharSequence) : ParsedCommand

--- a/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
+++ b/vector/src/main/java/im/vector/app/features/home/room/detail/composer/MessageComposerViewModel.kt
@@ -289,6 +289,11 @@ class MessageComposerViewModel @AssistedInject constructor(
                         is ParsedCommand.ErrorCommandNotSupportedInThreads -> {
                             _viewEvents.post(MessageComposerViewEvents.SlashCommandNotSupportedInThreads(parsedCommand.command))
                         }
+                        is ParsedCommand.SendVisioUrl -> {
+                            sendPrefixedMessage(room, generateVisioUrl(), parsedCommand.message, state.rootThreadEventId)
+                            _viewEvents.post(MessageComposerViewEvents.SlashCommandResultOk(parsedCommand))
+                            popDraft(room)
+                        }
                         is ParsedCommand.SendPlainText -> {
                             // Send the text message to the room, without markdown
                             if (state.rootThreadEventId != null) {
@@ -1067,5 +1072,14 @@ class MessageComposerViewModel @AssistedInject constructor(
         override fun create(initialState: MessageComposerViewState): MessageComposerViewModel
     }
 
-    companion object : MavericksViewModelFactory<MessageComposerViewModel, MessageComposerViewState> by hiltMavericksViewModelFactory()
+    companion object : MavericksViewModelFactory<MessageComposerViewModel, MessageComposerViewState> by hiltMavericksViewModelFactory() {
+        private const val LASUITE_VISIO_URL = "https://visio.numerique.gouv.fr/"
+        private const val ROOM_ID_ALLOWED_CHARACTERS = "abcdefghijklmnopqrstuvwxyz"
+
+        private fun getRandomChar() = ROOM_ID_ALLOWED_CHARACTERS.random()
+
+        private fun generateSegment(length: Int) = buildString { repeat(length) { append(getRandomChar()) } }
+
+        fun generateVisioUrl() = "$LASUITE_VISIO_URL${generateSegment(3)}-${generateSegment(4)}-${generateSegment(3)}"
+    }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Type of change

- [x] Feature
- [ ] Bugfix
- [ ] Technical
- [ ] Other :

## Content

<!-- Describe shortly what has been changed -->
Ajout d'une commande /visio pour créer un lien vers La Suite Visio

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!-- Only if UI have been changed
You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|
-->

![image](https://github.com/user-attachments/assets/12541d3b-2a37-4207-bb92-1dd14cbbdbc6)


<!--
|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [ ] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [ ] Changes has been tested on an Android device or Android emulator with API 21
- [ ] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#accessibility
- [ ] Pull request is based on the develop branch
- [ ] Pull request includes a new file under ./changelog.d. See https://github.com/tchapgouv/tchap-android/blob/develop/CONTRIBUTING.md#changelog
- [ ] Pull request includes screenshots or videos if containing UI changes
- [ ] Pull request includes a [sign off](https://matrix-org.github.io/synapse/latest/development/contributing_guide.html#sign-off)
- [ ] You've made a self review of your PR
- [ ] If you have modified the screen flow, or added new screens to the application, you have updated the test [UiAllScreensSanityTest.allScreensTest()](https://github.com/tchapgouv/tchap-android/blob/develop/vector/src/androidTest/java/im/vector/app/ui/UiAllScreensSanityTest.kt)
